### PR TITLE
feat(routes): add quiz management

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,11 +9,16 @@ from .routes.quizzes import bp as quizzes_bp
 
 def create_app(test_config=None):
     app = Flask(__name__, instance_relative_config=True)
+    
+    # PostgreSQL 연결 설정
     app.config.from_mapping(
-        DATABASE=os.path.join(app.instance_path, "app.sqlite"),
+        DATABASE_URL=os.environ.get('DATABASE_URL', 'postgresql://localhost/likebike'),
+
     )
+    
     if test_config:
         app.config.update(test_config)
+    
     try:
         os.makedirs(app.instance_path, exist_ok=True)
     except OSError:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,12 +1,27 @@
+import os
+
 from flask import Flask
+
+from . import db
 from .routes import main as main_blueprint
+from .routes.quizzes import bp as quizzes_bp
+
 
 def create_app(test_config=None):
-    app = Flask(__name__)
-
-    app.register_blueprint(main_blueprint)
-
+    app = Flask(__name__, instance_relative_config=True)
+    app.config.from_mapping(
+        DATABASE=os.path.join(app.instance_path, "app.sqlite"),
+    )
     if test_config:
         app.config.update(test_config)
+    try:
+        os.makedirs(app.instance_path, exist_ok=True)
+    except OSError:
+        pass
+
+    db.init_app(app)
+
+    app.register_blueprint(main_blueprint)
+    app.register_blueprint(quizzes_bp)
 
     return app

--- a/app/db.py
+++ b/app/db.py
@@ -1,15 +1,30 @@
 import os
-import sqlite3
-
+import psycopg2
+import psycopg2.extras
+import click
 from flask import current_app, g
+from flask.cli import with_appcontext
 
 SCHEMA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.sql")
 
 
 def get_db():
     if "db" not in g:
-        g.db = sqlite3.connect(current_app.config["DATABASE"])
-        g.db.row_factory = sqlite3.Row
+        if 'DATABASE_URL' in current_app.config:
+            g.db = psycopg2.connect(
+                current_app.config['DATABASE_URL'],
+                cursor_factory=psycopg2.extras.RealDictCursor
+            )
+        else:
+            g.db = psycopg2.connect(
+                host=current_app.config.get('DB_HOST', 'localhost'),
+                port=current_app.config.get('DB_PORT', 5432),
+                database=current_app.config.get('DB_NAME', 'likebike'),
+                user=current_app.config.get('DB_USER', os.environ.get('USER')),
+                password=current_app.config.get('DB_PASSWORD', ''),
+                cursor_factory=psycopg2.extras.RealDictCursor
+            )
+        g.db.autocommit = True
     return g.db
 
 
@@ -22,10 +37,22 @@ def close_db(e=None):
 def init_db():
     db = get_db()
     with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
-        db.executescript(f.read())
+        with db.cursor() as cur:
+            cur.execute(f.read())
+
+
+@click.command('init-db')
+@with_appcontext
+def init_db_command():
+    """Clear the existing data and create new tables."""
+    init_db()
+    click.echo('Initialized the database.')
 
 
 def init_app(app):
     app.teardown_appcontext(close_db)
-    with app.app_context():
-        init_db()
+    app.cli.add_command(init_db_command)
+    # 개발 환경에서만 자동 초기화
+    if app.config.get('TESTING'):
+        with app.app_context():
+            init_db()

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,31 @@
+import os
+import sqlite3
+
+from flask import current_app, g
+
+SCHEMA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.sql")
+
+
+def get_db():
+    if "db" not in g:
+        g.db = sqlite3.connect(current_app.config["DATABASE"])
+        g.db.row_factory = sqlite3.Row
+    return g.db
+
+
+def close_db(e=None):
+    db = g.pop("db", None)
+    if db is not None:
+        db.close()
+
+
+def init_db():
+    db = get_db()
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        db.executescript(f.read())
+
+
+def init_app(app):
+    app.teardown_appcontext(close_db)
+    with app.app_context():
+        init_db()

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,7 +1,8 @@
 from flask import Blueprint
 
-main = Blueprint('main', __name__)
+main = Blueprint("main", __name__)
 
-@main.route('/test')
+
+@main.route("/test")
 def test_route():
-    return 'hello world'
+    return "hello world"

--- a/app/routes/quizzes.py
+++ b/app/routes/quizzes.py
@@ -1,0 +1,106 @@
+from flask import Blueprint, jsonify, request
+
+from ..db import get_db
+
+bp = Blueprint("quizzes", __name__)
+
+
+def _require_admin():
+    if request.headers.get("X-Admin") != "true":
+        return jsonify({"error": "admin only"}), 403
+    return None
+
+
+@bp.route("/admin/quizzes", methods=["POST"])
+def create_quiz():
+    admin_check = _require_admin()
+    if admin_check:
+        return admin_check
+    data = request.get_json() or {}
+    question = data.get("question")
+    correct_answer = data.get("correct_answer")
+    if not question or not correct_answer:
+        return jsonify({"error": "question and correct_answer required"}), 400
+    db = get_db()
+    cur = db.execute(
+        "INSERT INTO quizzes (question, correct_answer) VALUES (?, ?)",
+        (question, correct_answer),
+    )
+    db.commit()
+    return jsonify({"id": cur.lastrowid, "question": question}), 201
+
+
+@bp.route("/admin/quizzes/<int:quiz_id>", methods=["PUT"])
+def update_quiz(quiz_id: int):
+    admin_check = _require_admin()
+    if admin_check:
+        return admin_check
+    data = request.get_json() or {}
+    question = data.get("question")
+    correct_answer = data.get("correct_answer")
+    db = get_db()
+    quiz = db.execute("SELECT id FROM quizzes WHERE id = ?", (quiz_id,)).fetchone()
+    if quiz is None:
+        return jsonify({"error": "quiz not found"}), 404
+    if question:
+        db.execute("UPDATE quizzes SET question = ? WHERE id = ?", (question, quiz_id))
+    if correct_answer:
+        db.execute(
+            "UPDATE quizzes SET correct_answer = ? WHERE id = ?",
+            (correct_answer, quiz_id),
+        )
+    db.commit()
+    quiz = db.execute(
+        "SELECT id, question, correct_answer FROM quizzes WHERE id = ?",
+        (quiz_id,),
+    ).fetchone()
+    return jsonify(
+        {
+            "id": quiz["id"],
+            "question": quiz["question"],
+            "correct_answer": quiz["correct_answer"],
+        }
+    )
+
+
+@bp.route("/admin/quizzes/<int:quiz_id>", methods=["DELETE"])
+def delete_quiz(quiz_id: int):
+    admin_check = _require_admin()
+    if admin_check:
+        return admin_check
+    db = get_db()
+    quiz = db.execute("SELECT id FROM quizzes WHERE id = ?", (quiz_id,)).fetchone()
+    if quiz is None:
+        return jsonify({"error": "quiz not found"}), 404
+    db.execute("DELETE FROM quizzes WHERE id = ?", (quiz_id,))
+    db.commit()
+    return "", 204
+
+
+@bp.route("/quizzes", methods=["GET"])
+def list_quizzes():
+    db = get_db()
+    quizzes = db.execute("SELECT id, question FROM quizzes").fetchall()
+    return jsonify([{"id": q["id"], "question": q["question"]} for q in quizzes])
+
+
+@bp.route("/quizzes/<int:quiz_id>/attempt", methods=["POST"])
+def attempt_quiz(quiz_id: int):
+    data = request.get_json() or {}
+    user_id = data.get("user_id")
+    answer = data.get("answer")
+    if user_id is None or answer is None:
+        return jsonify({"error": "user_id and answer required"}), 400
+    db = get_db()
+    quiz = db.execute(
+        "SELECT correct_answer FROM quizzes WHERE id = ?", (quiz_id,)
+    ).fetchone()
+    if quiz is None:
+        return jsonify({"error": "quiz not found"}), 404
+    is_correct = answer == quiz["correct_answer"]
+    db.execute(
+        "INSERT INTO user_quiz_attempts (user_id, quiz_id, is_correct) VALUES (?, ?, ?)",
+        (user_id, quiz_id, is_correct),
+    )
+    db.commit()
+    return jsonify({"is_correct": is_correct})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pytest
+psycopg2-binary

--- a/run.py
+++ b/run.py
@@ -2,5 +2,5 @@ from app import create_app
 
 app = create_app()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)

--- a/schema.sql
+++ b/schema.sql
@@ -1,8 +1,15 @@
--- Schema for LikeBike Backend
+-- filepath: /Users/hosunglim/Desktop/개인 프로젝트/LikeBike_backend/schema.sql
+DROP TABLE IF EXISTS user_quiz_attempts CASCADE;
+DROP TABLE IF EXISTS quizzes CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS bike_usage_logs CASCADE;
+DROP TABLE IF EXISTS news CASCADE;
+DROP TABLE IF EXISTS routes CASCADE;
+DROP TABLE IF EXISTS rewards CASCADE;
 
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
-    username VARCHAR(50) UNIQUE NOT NULL,
+    username VARCHAR(255) UNIQUE NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
     points INTEGER DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -17,40 +24,44 @@ CREATE TABLE quizzes (
 
 CREATE TABLE user_quiz_attempts (
     id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-    quiz_id INTEGER REFERENCES quizzes(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL,
+    quiz_id INTEGER NOT NULL,
     is_correct BOOLEAN NOT NULL,
-    attempted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    attempted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (quiz_id) REFERENCES quizzes (id) ON DELETE CASCADE
 );
 
 CREATE TABLE bike_usage_logs (
     id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL,
     description TEXT,
-    usage_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    usage_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
 CREATE TABLE news (
     id SERIAL PRIMARY KEY,
-    title VARCHAR(255) NOT NULL,
+    title TEXT NOT NULL,
     content TEXT NOT NULL,
     published_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE routes (
     id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-    name VARCHAR(255) NOT NULL,
+    user_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
     description TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
 CREATE TABLE rewards (
     id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-    source_type VARCHAR(50) NOT NULL,
+    user_id INTEGER NOT NULL,
+    source_type TEXT NOT NULL,
     source_id INTEGER,
     points INTEGER NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
-

--- a/tests/test_quizzes.py
+++ b/tests/test_quizzes.py
@@ -1,0 +1,60 @@
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app({"TESTING": True, "DATABASE": ":memory:"})
+    with app.test_client() as client:
+        yield client
+
+
+def test_admin_create_update_delete_quiz(client):
+    # create
+    res = client.post(
+        "/admin/quizzes",
+        json={"question": "Q1", "correct_answer": "A"},
+        headers={"X-Admin": "true"},
+    )
+    assert res.status_code == 201
+    quiz_id = res.get_json()["id"]
+
+    # update
+    res = client.put(
+        f"/admin/quizzes/{quiz_id}",
+        json={"question": "Q1 updated", "correct_answer": "B"},
+        headers={"X-Admin": "true"},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["question"] == "Q1 updated"
+
+    # delete
+    res = client.delete(f"/admin/quizzes/{quiz_id}", headers={"X-Admin": "true"})
+    assert res.status_code == 204
+
+
+def test_user_attempt_quiz(client):
+    # admin creates quiz first
+    res = client.post(
+        "/admin/quizzes",
+        json={"question": "What?", "correct_answer": "42"},
+        headers={"X-Admin": "true"},
+    )
+    quiz_id = res.get_json()["id"]
+
+    # user attempts correctly
+    res = client.post(
+        f"/quizzes/{quiz_id}/attempt",
+        json={"user_id": 1, "answer": "42"},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["is_correct"] is True
+
+    # user attempts wrong answer
+    res = client.post(
+        f"/quizzes/{quiz_id}/attempt",
+        json={"user_id": 1, "answer": "0"},
+    )
+    assert res.status_code == 200
+    assert res.get_json()["is_correct"] is False

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,14 +1,16 @@
 import pytest
+
 from app import create_app
+
 
 @pytest.fixture
 def client():
-    app = create_app({'TESTING': True})
+    app = create_app({"TESTING": True})
     with app.test_client() as client:
         yield client
 
 
 def test_test_route(client):
-    response = client.get('/test')
+    response = client.get("/test")
     assert response.status_code == 200
-    assert response.data.decode('utf-8') == 'hello world'
+    assert response.data.decode("utf-8") == "hello world"


### PR DESCRIPTION
### Description
- implement SQLite setup via db helpers
- add CRUD endpoints for quizzes with admin guard
- allow users to attempt quizzes
- register new blueprint and tests

### Testing Done
- `make lint` *(fails: No rule to make target)*
- `flake8` *(fails: command not found)*
- `mypy --strict app` *(fails with missing imports)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68483798225083219681a085c2e11870