### PR TITLE
feat(quizzes): add clova x generation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ python run.py
 
 Visit `http://localhost:5000/test` and you should see `hello world`.
 
+### Generating quizzes with Clova X
+
+There is an administrative endpoint that generates a quiz using Naver Clova X.
+Send a POST request to `/admin/quizzes/generate` with a JSON body containing a
+`prompt` field. The service will call Clova X, create a quiz record and return
+the created question and answer. Set the `CLOVA_API_KEY` environment variable to
+your Clova API key.
+
 ## Database Schema
 
 The PostgreSQL schema is defined in `schema.sql`. It outlines tables for users,

--- a/app/routes/quizzes.py
+++ b/app/routes/quizzes.py
@@ -1,8 +1,26 @@
+import asyncio
+import os
+
+import aiohttp
 from flask import Blueprint, jsonify, request
 
 from ..db import get_db
 
 bp = Blueprint("quizzes", __name__)
+
+CLOVA_API_URL = "https://clovastudio.apigw.ntruss.com/testapp/v1/chat/completions"
+
+
+async def _generate_from_clova(prompt: str, api_key: str) -> dict:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {"prompt": prompt}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(CLOVA_API_URL, headers=headers, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
 
 
 def _require_admin():
@@ -21,16 +39,21 @@ def create_quiz():
     correct_answer = data.get("correct_answer")
     if not question or not correct_answer:
         return jsonify({"error": "question and correct_answer required"}), 400
-    
+
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
             "INSERT INTO quizzes (question, correct_answer) VALUES (%s, %s) RETURNING id",
             (question, correct_answer),
         )
-        quiz_id = cur.fetchone()['id']
-    
-    return jsonify({"id": quiz_id, "question": question, "correct_answer": correct_answer}), 201
+        quiz_id = cur.fetchone()["id"]
+
+    return (
+        jsonify(
+            {"id": quiz_id, "question": question, "correct_answer": correct_answer}
+        ),
+        201,
+    )
 
 
 @bp.route("/admin/quizzes/<int:quiz_id>", methods=["PUT"])
@@ -43,7 +66,7 @@ def update_quiz(quiz_id):
     correct_answer = data.get("correct_answer")
     if not question or not correct_answer:
         return jsonify({"error": "question and correct_answer required"}), 400
-    
+
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
@@ -53,7 +76,7 @@ def update_quiz(quiz_id):
         result = cur.fetchone()
         if not result:
             return jsonify({"error": "quiz not found"}), 404
-    
+
     return jsonify(dict(result)), 200
 
 
@@ -62,14 +85,15 @@ def delete_quiz(quiz_id):
     admin_check = _require_admin()
     if admin_check:
         return admin_check
-    
+
     db = get_db()
     with db.cursor() as cur:
         cur.execute("DELETE FROM quizzes WHERE id = %s", (quiz_id,))
         if cur.rowcount == 0:
             return jsonify({"error": "quiz not found"}), 404
-    
+
     return "", 204
+
 
 @bp.route("/quizzes", methods=["GET"])
 def list_quizzes():
@@ -77,7 +101,7 @@ def list_quizzes():
     with db.cursor() as cur:
         cur.execute("SELECT id, question FROM quizzes")
         quizzes = cur.fetchall()
-    
+
     return jsonify(quizzes), 200
 
 
@@ -88,7 +112,7 @@ def attempt_quiz(quiz_id):
     answer = data.get("answer")
     if not user_id or not answer:
         return jsonify({"error": "user_id and answer required"}), 400
-    
+
     db = get_db()
     with db.cursor() as cur:
         # 퀴즈 정보 조회
@@ -96,13 +120,53 @@ def attempt_quiz(quiz_id):
         quiz = cur.fetchone()
         if not quiz:
             return jsonify({"error": "quiz not found"}), 404
-        
-        is_correct = answer == quiz['correct_answer']
-        
+
+        is_correct = answer == quiz["correct_answer"]
+
         # 시도 기록 저장
         cur.execute(
             "INSERT INTO user_quiz_attempts (user_id, quiz_id, is_correct) VALUES (%s, %s, %s)",
             (user_id, quiz_id, is_correct),
         )
-    
+
     return jsonify({"is_correct": is_correct}), 200
+
+
+@bp.route("/admin/quizzes/generate", methods=["POST"])
+def generate_quiz():
+    admin_check = _require_admin()
+    if admin_check:
+        return admin_check
+    data = request.get_json() or {}
+    prompt = data.get("prompt")
+    if not prompt:
+        return jsonify({"error": "prompt required"}), 400
+
+    api_key = os.environ.get("CLOVA_API_KEY")
+    if not api_key:
+        return jsonify({"error": "CLOVA_API_KEY not set"}), 500
+
+    try:
+        result = asyncio.run(_generate_from_clova(prompt, api_key))
+    except Exception:  # pragma: no cover - network errors
+        return jsonify({"error": "Failed to call Clova X"}), 502
+
+    question = result.get("question")
+    correct_answer = result.get("correct_answer")
+    if not question or not correct_answer:
+        return jsonify({"error": "invalid response from Clova X"}), 502
+
+    db = get_db()
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO quizzes (question, correct_answer) VALUES (%s, %s) RETURNING id",
+            (question, correct_answer),
+        )
+        quiz_id = cur.fetchone()["id"]
+
+    return (
+        jsonify(
+            {"id": quiz_id, "question": question, "correct_answer": correct_answer}
+        ),
+        201,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 pytest
 psycopg2-binary
+aiohttp

--- a/tests/test_quizzes.py
+++ b/tests/test_quizzes.py
@@ -1,18 +1,18 @@
 import pytest
 
 from app import create_app
-from app.db import init_db, get_db
+from app.db import get_db, init_db
 
 
 @pytest.fixture
 def app():
     # 테스트용 PostgreSQL 데이터베이스 사용
-    app = create_app({
-        "TESTING": True, 
-        "DATABASE_URL": "postgresql://localhost/likebike_test"
-    })
-    
+    app = create_app(
+        {"TESTING": True, "DATABASE_URL": "postgresql://localhost/likebike_test"}
+    )
+
     return app
+
 
 @pytest.fixture
 def client(app):
@@ -27,10 +27,11 @@ def test_user(app):
         with db.cursor() as cur:
             cur.execute(
                 "INSERT INTO users (username, email) VALUES (%s, %s) RETURNING id",
-                ("testuser", "test@example.com")
+                ("testuser", "test@example.com"),
             )
-            user_id = cur.fetchone()['id']
+            user_id = cur.fetchone()["id"]
         return user_id
+
 
 def test_admin_create_update_delete_quiz(client):
     # create
@@ -80,3 +81,22 @@ def test_user_attempt_quiz(client, test_user):
     )
     assert res.status_code == 200
     assert res.get_json()["is_correct"] is False
+
+
+def test_generate_quiz(client, monkeypatch):
+    async def fake_generate(prompt, api_key):
+        assert api_key == "dummy"
+        assert prompt == "make a quiz"
+        return {"question": "dummy q", "correct_answer": "dummy a"}
+
+    monkeypatch.setenv("CLOVA_API_KEY", "dummy")
+    monkeypatch.setattr("app.routes.quizzes._generate_from_clova", fake_generate)
+
+    res = client.post(
+        "/admin/quizzes/generate",
+        json={"prompt": "make a quiz"},
+        headers={"X-Admin": "true"},
+    )
+    assert res.status_code == 201
+    assert res.get_json()["question"] == "dummy q"
+    assert res.get_json()["correct_answer"] == "dummy a"


### PR DESCRIPTION
### Description
- integrate Naver Clova X via aiohttp
- add `/admin/quizzes/generate` route to create quiz items from prompts
- manage API key via `CLOVA_API_KEY`
- document new endpoint in README
- add basic test with fake generator

### Testing Done
- `black app/routes/quizzes.py tests/test_quizzes.py` *(passes)*
- `isort app/routes/quizzes.py tests/test_quizzes.py` *(passes)*
- `mypy --strict app` *(fails: missing stubs)*
- `flake8 app/routes/quizzes.py tests/test_quizzes.py` *(command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for flask)*


------
https://chatgpt.com/codex/tasks/task_e_684843b625048321932db25c51c1afd0