### PR TITLE
feat(responses): return data arrays

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,8 +1,10 @@
 from flask import Blueprint
 
+from ..utils.responses import make_response
+
 main = Blueprint("main", __name__)
 
 
 @main.route("/test")
 def test_route():
-    return "hello world"
+    return make_response("hello world")

--- a/app/routes/bike_logs.py
+++ b/app/routes/bike_logs.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, request
+
+from ..utils.responses import make_response
 
 from ..db import get_db
 
@@ -10,7 +12,7 @@ def create_bike_log(user_id):
     data = request.get_json() or {}
     description = data.get("description")
     if not description:
-        return jsonify({"error": "description required"}), 400
+        return make_response({"error": "description required"}, 400)
 
     db = get_db()
     with db.cursor() as cur:
@@ -20,7 +22,7 @@ def create_bike_log(user_id):
         )
         log = cur.fetchone()
 
-    return jsonify(dict(log)), 201
+    return make_response(dict(log), 201)
 
 
 @bp.route("/users/<int:user_id>/bike-logs", methods=["GET"])
@@ -33,7 +35,7 @@ def list_bike_logs(user_id):
         )
         logs = cur.fetchall()
 
-    return jsonify(logs), 200
+    return make_response(logs)
 
 
 @bp.route("/bike-logs/<int:log_id>", methods=["PUT"])
@@ -41,7 +43,7 @@ def update_bike_log(log_id):
     data = request.get_json() or {}
     description = data.get("description")
     if description is None:
-        return jsonify({"error": "description required"}), 400
+        return make_response({"error": "description required"}, 400)
 
     db = get_db()
     with db.cursor() as cur:
@@ -51,9 +53,9 @@ def update_bike_log(log_id):
         )
         log = cur.fetchone()
         if not log:
-            return jsonify({"error": "log not found"}), 404
+            return make_response({"error": "log not found"}, 404)
 
-    return jsonify(dict(log)), 200
+    return make_response(dict(log))
 
 
 @bp.route("/bike-logs/<int:log_id>", methods=["DELETE"])
@@ -62,6 +64,6 @@ def delete_bike_log(log_id):
     with db.cursor() as cur:
         cur.execute("DELETE FROM bike_usage_logs WHERE id = %s", (log_id,))
         if cur.rowcount == 0:
-            return jsonify({"error": "log not found"}), 404
+            return make_response({"error": "log not found"}, 404)
 
-    return "", 204
+    return make_response(None, 204)

--- a/app/utils/responses.py
+++ b/app/utils/responses.py
@@ -1,0 +1,17 @@
+from http import HTTPStatus
+from typing import Any
+
+from flask import jsonify
+
+
+def make_response(data: Any = None, code: int = 200):
+    """Return a standardized JSON response with data always as a list."""
+    if data is None:
+        payload = []
+    elif isinstance(data, list):
+        payload = data
+    else:
+        payload = [data]
+
+    message = HTTPStatus(code).phrase
+    return jsonify({"code": code, "message": message, "data": payload}), code

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -12,8 +12,9 @@ erDiagram
     }
     quizzes {
         integer id PK
-        text question
-        text correct_answer
+        string question
+        string correct_answer
+        string[] answers
         timestamp created_at
     }
     user_quiz_attempts {
@@ -26,20 +27,20 @@ erDiagram
     bike_usage_logs {
         integer id PK
         integer user_id FK
-        text description
+        string description
         timestamp usage_time
     }
     news {
         integer id PK
         varchar title
-        text content
+        string content
         timestamp published_at
     }
     routes {
         integer id PK
         integer user_id FK
         varchar name
-        text description
+        string description
         timestamp created_at
     }
     rewards {
@@ -51,9 +52,9 @@ erDiagram
         timestamp created_at
     }
 
-    users ||--o{ user_quiz_attempts : "" 
-    quizzes ||--o{ user_quiz_attempts : "" 
-    users ||--o{ bike_usage_logs : "" 
-    users ||--o{ routes : "" 
-    users ||--o{ rewards : "" 
+    users ||--o{ user_quiz_attempts : ""
+    quizzes ||--o{ user_quiz_attempts : ""
+    users ||--o{ bike_usage_logs : ""
+    users ||--o{ routes : ""
+    users ||--o{ rewards : ""
 ```

--- a/tests/test_bike_logs.py
+++ b/tests/test_bike_logs.py
@@ -36,12 +36,12 @@ def test_bike_log_crud(client, test_user):
         json={"description": "morning ride"},
     )
     assert res.status_code == 201
-    log_id = res.get_json()["id"]
+    log_id = res.get_json()["data"][0]["id"]
 
     # list logs
     res = client.get(f"/users/{test_user}/bike-logs")
     assert res.status_code == 200
-    logs = res.get_json()
+    logs = res.get_json()["data"]
     assert len(logs) == 1
     assert logs[0]["description"] == "morning ride"
 
@@ -51,7 +51,7 @@ def test_bike_log_crud(client, test_user):
         json={"description": "evening ride"},
     )
     assert res.status_code == 200
-    assert res.get_json()["description"] == "evening ride"
+    assert res.get_json()["data"][0]["description"] == "evening ride"
 
     # delete log
     res = client.delete(f"/bike-logs/{log_id}")
@@ -60,4 +60,4 @@ def test_bike_log_crud(client, test_user):
     # list logs after deletion
     res = client.get(f"/users/{test_user}/bike-logs")
     assert res.status_code == 200
-    assert res.get_json() == []
+    assert res.get_json()["data"] == []

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -24,7 +24,7 @@ def test_admin_create_update_delete_news(client):
         headers={"X-Admin": "true"},
     )
     assert res.status_code == 201
-    news_id = res.get_json()["id"]
+    news_id = res.get_json()["data"][0]["id"]
 
     res = client.put(
         f"/admin/news/{news_id}",
@@ -32,7 +32,7 @@ def test_admin_create_update_delete_news(client):
         headers={"X-Admin": "true"},
     )
     assert res.status_code == 200
-    assert res.get_json()["title"] == "T1 updated"
+    assert res.get_json()["data"][0]["title"] == "T1 updated"
 
     res = client.delete(f"/admin/news/{news_id}", headers={"X-Admin": "true"})
     assert res.status_code == 204
@@ -52,4 +52,4 @@ def test_list_news(client):
 
     res = client.get("/news")
     assert res.status_code == 200
-    assert len(res.get_json()) >= 2
+    assert len(res.get_json()["data"]) >= 2

--- a/tests/test_quizzes.py
+++ b/tests/test_quizzes.py
@@ -41,7 +41,7 @@ def test_admin_create_update_delete_quiz(client):
         headers={"X-Admin": "true"},
     )
     assert res.status_code == 201
-    quiz_id = res.get_json()["id"]
+    quiz_id = res.get_json()["data"][0]["id"]
 
     # update
     res = client.put(
@@ -50,7 +50,7 @@ def test_admin_create_update_delete_quiz(client):
         headers={"X-Admin": "true"},
     )
     assert res.status_code == 200
-    assert res.get_json()["question"] == "Q1 updated"
+    assert res.get_json()["data"][0]["question"] == "Q1 updated"
 
     # delete
     res = client.delete(f"/admin/quizzes/{quiz_id}", headers={"X-Admin": "true"})
@@ -64,7 +64,7 @@ def test_user_attempt_quiz(client, test_user):
         json={"question": "What?", "correct_answer": "42"},
         headers={"X-Admin": "true"},
     )
-    quiz_id = res.get_json()["id"]
+    quiz_id = res.get_json()["data"][0]["id"]
 
     # user attempts correctly
     res = client.post(
@@ -72,7 +72,7 @@ def test_user_attempt_quiz(client, test_user):
         json={"user_id": test_user, "answer": "42"},
     )
     assert res.status_code == 200
-    assert res.get_json()["is_correct"] is True
+    assert res.get_json()["data"][0]["is_correct"] is True
 
     # user attempts wrong answer
     res = client.post(
@@ -80,7 +80,7 @@ def test_user_attempt_quiz(client, test_user):
         json={"user_id": test_user, "answer": "0"},
     )
     assert res.status_code == 200
-    assert res.get_json()["is_correct"] is False
+    assert res.get_json()["data"][0]["is_correct"] is False
 
 
 def test_generate_quiz(client, monkeypatch):
@@ -98,5 +98,5 @@ def test_generate_quiz(client, monkeypatch):
         headers={"X-Admin": "true"},
     )
     assert res.status_code == 201
-    assert res.get_json()["question"] == "dummy q"
-    assert res.get_json()["correct_answer"] == "dummy a"
+    assert res.get_json()["data"][0]["question"] == "dummy q"
+    assert res.get_json()["data"][0]["correct_answer"] == "dummy a"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -13,4 +13,8 @@ def client():
 def test_test_route(client):
     response = client.get("/test")
     assert response.status_code == 200
-    assert response.data.decode("utf-8") == "hello world"
+    assert response.get_json() == {
+        "code": 200,
+        "message": "OK",
+        "data": ["hello world"],
+    }

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -29,11 +29,11 @@ def test_register_update_delete_user(client, monkeypatch, app):
 
     res = client.post("/users", json={"access_token": "token"})
     assert res.status_code == 201
-    user_id = res.get_json()["id"]
+    user_id = res.get_json()["data"][0]["id"]
 
     res = client.put(f"/users/{user_id}", json={"username": "updated"})
     assert res.status_code == 200
-    assert res.get_json()["username"] == "updated"
+    assert res.get_json()["data"][0]["username"] == "updated"
 
     res = client.delete(f"/users/{user_id}")
     assert res.status_code == 204


### PR DESCRIPTION
### Description
- update `make_response` so `data` is always returned as a list
- adjust sample route test and other unit tests for the new structure

### Testing Done
- `make lint` *(fails: No rule to make target 'lint')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685b72daee9c83219f00451e569b4d3e