### PR TITLE
feat(rewards): add user rewards history endpoint

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -38,8 +38,8 @@ def test_route():
 # 모든 라우트 블루프린트를 등록하는 함수
 def register_routes(app):
     """애플리케이션에 모든 라우트를 등록"""
-    from . import users, bike_logs, community, news, quizzes, storage
-    
+    from . import users, bike_logs, community, news, quizzes, storage, rewards
+
     app.register_blueprint(main)
     app.register_blueprint(users.bp)
     app.register_blueprint(bike_logs.bp)
@@ -47,3 +47,4 @@ def register_routes(app):
     app.register_blueprint(news.bp)
     app.register_blueprint(quizzes.bp)
     app.register_blueprint(storage.bp)
+    app.register_blueprint(rewards.bp)

--- a/app/routes/rewards.py
+++ b/app/routes/rewards.py
@@ -10,7 +10,54 @@ bp = Blueprint("rewards", __name__)
 @bp.route("/users/rewards", methods=["GET"])
 @jwt_required
 def get_user_rewards():
-    """사용자 포인트 적립 내역 조회"""
+    """
+    사용자 포인트 적립 내역 조회
+    ---
+    tags:
+      - Rewards
+    summary: 로그인한 사용자의 포인트 적립 내역 조회
+    description: 현재 로그인한 사용자의 포인트 적립(리워드) 내역을 최근 순으로 반환합니다.
+    security:
+      - JWT: []
+    responses:
+      200:
+        description: 포인트 적립 내역 조회 성공
+        schema:
+          type: object
+          properties:
+            code:
+              type: integer
+              example: 200
+            message:
+              type: string
+              example: "OK"
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 1
+                  user_id:
+                    type: integer
+                    example: 1
+                  source_type:
+                    type: string
+                    example: "quiz"
+                  points:
+                    type: integer
+                    example: 10
+                  reward_reason:
+                    type: string
+                    example: "퀴즈 정답"
+                  created_at:
+                    type: string
+                    format: date-time
+                    example: "2024-01-01T12:00:00Z"
+      401:
+        description: 인증 실패
+    """
     user_id = get_current_user_id()
     db = get_db()
     with db.cursor() as cur:

--- a/app/routes/rewards.py
+++ b/app/routes/rewards.py
@@ -1,0 +1,22 @@
+from flask import Blueprint
+
+from ..db import get_db
+from ..utils.auth import get_current_user_id, jwt_required
+from ..utils.responses import make_response
+
+bp = Blueprint("rewards", __name__)
+
+
+@bp.route("/users/rewards", methods=["GET"])
+@jwt_required
+def get_user_rewards():
+    """사용자 포인트 적립 내역 조회"""
+    user_id = get_current_user_id()
+    db = get_db()
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT * FROM rewards WHERE user_id = %s ORDER BY created_at DESC",
+            (user_id,),
+        )
+        rewards = cur.fetchall()
+    return make_response([dict(r) for r in rewards])

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -2,6 +2,7 @@ import pytest
 
 from app import create_app
 from tests.test_helpers import get_test_jwt_token, get_auth_headers
+from app.db import get_db
 
 
 @pytest.fixture
@@ -18,6 +19,7 @@ def client(app):
 
 def test_register_user(client, monkeypatch, app):
     """사용자 등록/로그인 테스트 (JWT 토큰 발급 확인)"""
+
     async def fake_fetch(token: str):
         return {
             "id": 999,
@@ -25,7 +27,7 @@ def test_register_user(client, monkeypatch, app):
                 "email": "test@kakao.com",
                 "profile": {
                     "nickname": "kakao_user",
-                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg"
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
                 },
             },
         }
@@ -43,6 +45,7 @@ def test_register_user(client, monkeypatch, app):
 
 def test_update_user_profile(client, monkeypatch, app):
     """사용자 프로필 수정 테스트 (JWT 인증 필요)"""
+
     # 먼저 사용자 등록
     async def fake_fetch(token: str):
         return {
@@ -51,25 +54,32 @@ def test_update_user_profile(client, monkeypatch, app):
                 "email": "test@kakao.com",
                 "profile": {
                     "nickname": "kakao_user",
-                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg"
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
                 },
             },
         }
 
     monkeypatch.setattr("app.routes.users.fetch_kakao_user_info", fake_fetch)
-    
+
     # 사용자 등록 후 JWT 토큰 획득
     res = client.post("/users", json={"access_token": "token"})
     user_data = res.get_json()["data"][0]
     user_id = user_data["id"]
     jwt_token = user_data["access_token"]
-    
+
     # JWT 토큰으로 프로필 수정 (프로필 이미지 포함)
-    headers = {"Authorization": f"Bearer {jwt_token}", "Content-Type": "application/json"}
-    res = client.put("/users/profile", json={
-        "username": "updated",
-        "profile_image_url": "https://k.kakaocdn.net/dn/updated_profile.jpg"
-    }, headers=headers)
+    headers = {
+        "Authorization": f"Bearer {jwt_token}",
+        "Content-Type": "application/json",
+    }
+    res = client.put(
+        "/users/profile",
+        json={
+            "username": "updated",
+            "profile_image_url": "https://k.kakaocdn.net/dn/updated_profile.jpg",
+        },
+        headers=headers,
+    )
     assert res.status_code == 200
     data = res.get_json()["data"][0]
     assert data["username"] == "updated"
@@ -78,6 +88,7 @@ def test_update_user_profile(client, monkeypatch, app):
 
 def test_delete_user_profile(client, monkeypatch, app):
     """사용자 계정 삭제 테스트 (JWT 인증 필요)"""
+
     # 먼저 사용자 등록
     async def fake_fetch(token: str):
         return {
@@ -86,17 +97,17 @@ def test_delete_user_profile(client, monkeypatch, app):
                 "email": "test@kakao.com",
                 "profile": {
                     "nickname": "kakao_user",
-                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg"
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
                 },
             },
         }
 
     monkeypatch.setattr("app.routes.users.fetch_kakao_user_info", fake_fetch)
-    
+
     # 사용자 등록 후 JWT 토큰 획득
     res = client.post("/users", json={"access_token": "token"})
     jwt_token = res.get_json()["data"][0]["access_token"]
-    
+
     # JWT 토큰으로 계정 삭제
     headers = {"Authorization": f"Bearer {jwt_token}"}
     res = client.delete("/users/profile", headers=headers)
@@ -105,6 +116,7 @@ def test_delete_user_profile(client, monkeypatch, app):
 
 def test_get_user_profile(client, monkeypatch, app):
     """사용자 프로필 조회 테스트 (JWT 인증 필요)"""
+
     # 먼저 사용자 등록
     async def fake_fetch(token: str):
         return {
@@ -113,17 +125,17 @@ def test_get_user_profile(client, monkeypatch, app):
                 "email": "test@kakao.com",
                 "profile": {
                     "nickname": "kakao_user",
-                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg"
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
                 },
             },
         }
 
     monkeypatch.setattr("app.routes.users.fetch_kakao_user_info", fake_fetch)
-    
+
     # 사용자 등록 후 JWT 토큰 획득
     res = client.post("/users", json={"access_token": "token"})
     jwt_token = res.get_json()["data"][0]["access_token"]
-    
+
     # JWT 토큰으로 프로필 조회
     headers = {"Authorization": f"Bearer {jwt_token}"}
     res = client.get("/users/profile", headers=headers)
@@ -140,11 +152,11 @@ def test_unauthorized_access(client):
     res = client.get("/users/profile")
     assert res.status_code == 401
     assert "Authorization token required" in res.get_json()["data"][0]["error"]
-    
+
     # 토큰 없이 프로필 수정 시도
     res = client.put("/users/profile", json={"username": "test"})
     assert res.status_code == 401
-    
+
     # 토큰 없이 계정 삭제 시도
     res = client.delete("/users/profile")
     assert res.status_code == 401
@@ -152,8 +164,11 @@ def test_unauthorized_access(client):
 
 def test_invalid_token_access(client):
     """잘못된 JWT 토큰으로 접근 테스트"""
-    headers = {"Authorization": "Bearer invalid_token", "Content-Type": "application/json"}
-    
+    headers = {
+        "Authorization": "Bearer invalid_token",
+        "Content-Type": "application/json",
+    }
+
     res = client.get("/users/profile", headers=headers)
     assert res.status_code == 401
     assert "Invalid or expired token" in res.get_json()["data"][0]["error"]
@@ -161,6 +176,7 @@ def test_invalid_token_access(client):
 
 def test_logout(client, monkeypatch):
     """로그아웃 테스트"""
+
     # 사용자 등록
     async def fake_fetch(token: str):
         return {
@@ -169,16 +185,16 @@ def test_logout(client, monkeypatch):
                 "email": "test@kakao.com",
                 "profile": {
                     "nickname": "kakao_user",
-                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg"
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
                 },
             },
         }
 
     monkeypatch.setattr("app.routes.users.fetch_kakao_user_info", fake_fetch)
-    
+
     res = client.post("/users", json={"access_token": "token"})
     jwt_token = res.get_json()["data"][0]["access_token"]
-    
+
     # 로그아웃
     headers = {"Authorization": f"Bearer {jwt_token}"}
     res = client.post("/users/logout", headers=headers)
@@ -189,7 +205,7 @@ def test_logout(client, monkeypatch):
 def test_token_refresh(client, monkeypatch):
     """토큰 새로고침 테스트"""
     import time
-    
+
     # 사용자 등록
     async def fake_fetch(token: str):
         return {
@@ -198,7 +214,7 @@ def test_token_refresh(client, monkeypatch):
                 "email": "test@kakao.com",
                 "profile": {
                     "nickname": "kakao_user",
-                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg"
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
                 },
             },
         }
@@ -207,7 +223,7 @@ def test_token_refresh(client, monkeypatch):
 
     res = client.post("/users", json={"access_token": "token"})
     old_token = res.get_json()["data"][0]["access_token"]
-    
+
     # 시간을 조금 지연시켜 다른 iat를 가지도록 함
     time.sleep(1)
 
@@ -217,3 +233,44 @@ def test_token_refresh(client, monkeypatch):
     assert res.status_code == 200
     new_token = res.get_json()["data"][0]["access_token"]
     assert new_token != old_token  # 새로운 토큰이 생성되어야 함
+
+
+def test_get_user_rewards(client, monkeypatch, app):
+    async def fake_fetch(token: str):
+        return {
+            "id": 999,
+            "kakao_account": {
+                "email": "test@kakao.com",
+                "profile": {
+                    "nickname": "kakao_user",
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
+                },
+            },
+        }
+
+    monkeypatch.setattr("app.routes.users.fetch_kakao_user_info", fake_fetch)
+
+    res = client.post("/users", json={"access_token": "token"})
+    data = res.get_json()["data"][0]
+    jwt_token = data["access_token"]
+    user_id = data["id"]
+
+    with app.app_context():
+        db = get_db()
+        with db.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO rewards (user_id, source_type, points, reward_reason)
+                VALUES (%s, %s, %s, %s) RETURNING id
+                """,
+                (user_id, "test", 5, "테스트"),
+            )
+            reward_id = cur.fetchone()["id"]
+
+    headers = {"Authorization": f"Bearer {jwt_token}"}
+    res = client.get("/users/rewards", headers=headers)
+    assert res.status_code == 200
+    rewards = res.get_json()["data"]
+    assert len(rewards) == 1
+    assert rewards[0]["id"] == reward_id
+    assert rewards[0]["points"] == 5


### PR DESCRIPTION
### Description
- allow members to query their reward history via `/users/rewards`
- register new rewards blueprint
- add unit test covering the new endpoint

### Testing Done
- `pytest -q` *(fails: ModuleNotFoundError for `flask`)*

------
https://chatgpt.com/codex/tasks/task_e_687dbb8730c48321a3b4349509fb90f3