### PR TITLE
fix(routes): close storage blueprint call

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -38,7 +38,8 @@ def test_route():
 # 모든 라우트 블루프린트를 등록하는 함수
 def register_routes(app):
     """애플리케이션에 모든 라우트를 등록"""
-    from . import users, bike_logs, community, news, quizzes, storage, rewards, recommendations
+    from . import (bike_logs, community, news, quizzes, recommendations,
+                   rewards, storage, users)
 
     app.register_blueprint(main)
     app.register_blueprint(users.bp)
@@ -46,6 +47,6 @@ def register_routes(app):
     app.register_blueprint(community.bp)
     app.register_blueprint(news.bp)
     app.register_blueprint(quizzes.bp)
-    app.register_blueprint(storage.bp
+    app.register_blueprint(storage.bp)
     app.register_blueprint(recommendations.bp)
     app.register_blueprint(rewards.bp)


### PR DESCRIPTION
### Description
Fixes a syntax error in `register_routes` that left a blueprint registration
incomplete.

### Testing Done
- `black .`
- `isort .`
- `flake8` *(command not found)*
- `mypy --strict .` *(errors: missing stubs)*
- `pytest -q` *(failed: ModuleNotFoundError due to missing deps)*


------
https://chatgpt.com/codex/tasks/task_e_6880418d9d808321b3f063f2bef710c2