### PR TITLE
feat(users): add withdraw endpoint

### DIFF
--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -274,15 +274,32 @@ def update_user():
     return make_response(dict(updated))
 
 
+def _remove_user(user_id: int) -> int:
+    db = get_db()
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
+        return cur.rowcount
+
+
 @bp.route("/users/profile", methods=["DELETE"])
 @jwt_required
 def delete_user():
     user_id = get_current_user_id()
-    db = get_db()
-    with db.cursor() as cur:
-        cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
-        if cur.rowcount == 0:
-            return make_response({"error": "user not found"}, 404)
+    deleted = _remove_user(user_id)
+    if deleted == 0:
+        return make_response({"error": "user not found"}, 404)
+
+    return make_response(None, 204)
+
+
+@bp.route("/users/withdraw", methods=["DELETE"])
+@jwt_required
+def withdraw_user():
+    """사용자가 자신의 계정을 완전히 삭제합니다."""
+    user_id = get_current_user_id()
+    deleted = _remove_user(user_id)
+    if deleted == 0:
+        return make_response({"error": "user not found"}, 404)
 
     return make_response(None, 204)
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -114,6 +114,31 @@ def test_delete_user_profile(client, monkeypatch, app):
     assert res.status_code == 204
 
 
+def test_withdraw_user(client, monkeypatch):
+    """신규 회원 탈퇴 엔드포인트 테스트"""
+
+    async def fake_fetch(token: str):
+        return {
+            "id": 999,
+            "kakao_account": {
+                "email": "test@kakao.com",
+                "profile": {
+                    "nickname": "kakao_user",
+                    "profile_image_url": "https://k.kakaocdn.net/dn/test_profile.jpg",
+                },
+            },
+        }
+
+    monkeypatch.setattr("app.routes.users.fetch_kakao_user_info", fake_fetch)
+
+    res = client.post("/users", json={"access_token": "token"})
+    jwt_token = res.get_json()["data"][0]["access_token"]
+
+    headers = {"Authorization": f"Bearer {jwt_token}"}
+    res = client.delete("/users/withdraw", headers=headers)
+    assert res.status_code == 204
+
+
 def test_get_user_profile(client, monkeypatch, app):
     """사용자 프로필 조회 테스트 (JWT 인증 필요)"""
 


### PR DESCRIPTION
### Description
- add helper for deleting user accounts
- expose new `DELETE /users/withdraw` endpoint
- test withdrawal route

### Testing Done
- `black --check app/routes/users.py tests/test_users.py` *(fails: would reformat)*
- `isort --check-only app/routes/users.py tests/test_users.py` *(fails: imports unsorted)*
- `pytest -q` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880d47f2914832189a872f7d923e95d