### PR TITLE
feat(quizzes): add explanation field

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Swagger UI를 통해 모든 API를 손쉽게 테스트할 수 있습니다.
 
 ### 퀴즈 관련 변경 사항
 
+- 각 퀴즈는 `explanation` 필드로 정답 해설을 포함합니다.
 - 퀴즈 생성 시 `display_date` 필드를 사용해 문제를 노출할 날짜를 지정합니다.
 - `/quizzes` 목록 조회 응답에 `display_date`가 포함됩니다.
 - `/quizzes/today/status` 엔드포인트로 사용자가 오늘 퀴즈를 풀었는지 확인할 수 있습니다.

--- a/app/routes/quizzes.py
+++ b/app/routes/quizzes.py
@@ -50,6 +50,7 @@ def create_quiz():
             - correct_answer
             - answers
             - hint_link
+            - explanation
             - display_date
           properties:
             question:
@@ -64,6 +65,10 @@ def create_quiz():
               type: string
               description: 힌트에 대한 사이트 링크
               example: "https://example.com/hint"
+            explanation:
+              type: string
+              description: 정답 해설
+              example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
             answers:
               type: array
               description: 선택지 배열 (정답 포함)
@@ -125,6 +130,7 @@ def create_quiz():
     correct_answer = data.get("correct_answer")
     answers = data.get("answers", [])  # 선택지 배열
     hint_link = data.get("hint_link")
+    explanation = data.get("explanation")
     display_date = data.get("display_date") or date.today()
     if not question or not correct_answer:
         return make_response({"error": "question and correct_answer required"}, 400)
@@ -132,8 +138,8 @@ def create_quiz():
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "INSERT INTO quizzes (question, correct_answer, answers, hint_link, display_date) VALUES (%s, %s, %s, %s, %s) RETURNING id",
-            (question, correct_answer, answers, hint_link, display_date),
+            "INSERT INTO quizzes (question, correct_answer, answers, hint_link, explanation, display_date) VALUES (%s, %s, %s, %s, %s, %s) RETURNING id",
+            (question, correct_answer, answers, hint_link, explanation, display_date),
         )
         quiz_id = cur.fetchone()["id"]
 
@@ -144,6 +150,7 @@ def create_quiz():
             "hint_link": hint_link,
             "correct_answer": correct_answer,
             "answers": answers,
+            "explanation": explanation,
             "display_date": display_date.isoformat(),
         },
         201,
@@ -180,6 +187,7 @@ def update_quiz(quiz_id):
             - correct_answer
             - answers
             - hint_link
+            - explanation
           properties:
             question:
               type: string
@@ -199,6 +207,10 @@ def update_quiz(quiz_id):
               type: string
               description: 힌트에 대한 사이트 링크
               example: "https://example.com/hint"
+            explanation:
+              type: string
+              description: 정답 해설
+              example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
     responses:
       200:
         description: 퀴즈 수정 성공
@@ -233,6 +245,9 @@ def update_quiz(quiz_id):
                   hint_link:
                     type: string
                     example: "https://example.com/hint"
+                  explanation:
+                    type: string
+                    example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
                   display_date:
                     type: string
                     format: date
@@ -251,14 +266,15 @@ def update_quiz(quiz_id):
     correct_answer = data.get("correct_answer")
     answers = data.get("answers", [])
     hint_link = data.get("hint_link")
+    explanation = data.get("explanation")
     if not question or not correct_answer:
         return make_response({"error": "question and correct_answer required"}, 400)
 
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "UPDATE quizzes SET question = %s, correct_answer = %s, answers = %s, hint_link = %s WHERE id = %s RETURNING id, question, correct_answer, answers, hint_link",
-            (question, correct_answer, answers, hint_link, quiz_id),
+            "UPDATE quizzes SET question = %s, correct_answer = %s, answers = %s, hint_link = %s, explanation = %s WHERE id = %s RETURNING id, question, correct_answer, answers, hint_link, explanation",
+            (question, correct_answer, answers, hint_link, explanation, quiz_id),
         )
         result = cur.fetchone()
         if not result:
@@ -355,6 +371,9 @@ def list_quizzes():
                   hint_link:
                     type: string
                     example: "https://example.com/hint"
+                  explanation:
+                    type: string
+                    example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
                   display_date:
                     type: string
                     format: date
@@ -365,7 +384,7 @@ def list_quizzes():
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "SELECT id, question, answers, hint_link, display_date FROM quizzes"
+            "SELECT id, question, answers, hint_link, explanation, display_date FROM quizzes"
         )
         quizzes = cur.fetchall()
     for q in quizzes:

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -48,6 +48,7 @@ erDiagram
         string correct_answer
         string[] answers
         varchar hint_link
+        text explanation
         date display_date
         timestamp created_at
     }

--- a/schema.sql
+++ b/schema.sql
@@ -73,6 +73,7 @@ CREATE TABLE quizzes (
     correct_answer TEXT NOT NULL,
     answers TEXT[], -- PostgreSQL array for multiple choice answers
     hint_link VARCHAR(512),
+    explanation TEXT,
     display_date DATE DEFAULT CURRENT_DATE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/swagger_config.py
+++ b/swagger_config.py
@@ -152,6 +152,10 @@ QUIZ_MODEL = {
             "items": {"type": "string"},
             "example": ["모자", "선글라스", "헬멧", "장갑"],
         },
+        "explanation": {
+            "type": "string",
+            "example": "헬멧은 머리를 보호하기 위한 필수 장비입니다.",
+        },
     },
 }
 

--- a/tests/test_quizzes.py
+++ b/tests/test_quizzes.py
@@ -74,6 +74,7 @@ def test_admin_create_update_delete_quiz(client, test_admin_user):
         "correct_answer": "A",
         "answers": ["A", "B", "C"],
         "hint_link": "http://hint1.com",
+        "explanation": "정답은 A 입니다",
         "display_date": "2024-01-01",
     }
     res = client.post(
@@ -88,6 +89,7 @@ def test_admin_create_update_delete_quiz(client, test_admin_user):
     assert data["correct_answer"] == "A"
     assert data["answers"] == ["A", "B", "C"]
     assert data["hint_link"] == "http://hint1.com"
+    assert data["explanation"] == "정답은 A 입니다"
     assert data["display_date"] == "2024-01-01"
     quiz_id = data["id"]
 
@@ -97,6 +99,7 @@ def test_admin_create_update_delete_quiz(client, test_admin_user):
         "correct_answer": "B",
         "answers": ["X", "Y", "Z"],
         "hint_link": "http://hint_updated.com",
+        "explanation": "업데이트 해설",
     }
     res = client.put(
         f"/admin/quizzes/{quiz_id}",
@@ -109,6 +112,7 @@ def test_admin_create_update_delete_quiz(client, test_admin_user):
     assert data["correct_answer"] == "B"
     assert data["answers"] == ["X", "Y", "Z"]
     assert data["hint_link"] == "http://hint_updated.com"
+    assert data["explanation"] == "업데이트 해설"
 
     # delete
     res = client.delete(f"/admin/quizzes/{quiz_id}", headers=admin_headers)
@@ -132,6 +136,7 @@ def test_user_attempt_quiz(client, test_user, test_admin_user):
             "correct_answer": "42",
             "answers": ["40", "41", "42"],
             "hint_link": "http://hint_answer.com",
+            "explanation": "answer is 42",
         },
         headers=admin_headers,
     )
@@ -172,6 +177,7 @@ def test_list_quizzes(client, test_user, test_admin_user):
         "correct_answer": "Test Answer",
         "answers": ["A", "B", "Test Answer"],
         "hint_link": "http://test_hint.com",
+        "explanation": "테스트 해설",
         "display_date": "2024-01-01",
     }
     client.post(
@@ -199,6 +205,7 @@ def test_list_quizzes(client, test_user, test_admin_user):
     assert "Test Answer" in found_quiz["answers"]
     assert "hint_link" in found_quiz
     assert found_quiz["hint_link"] == "http://test_hint.com"
+    assert found_quiz["explanation"] == "테스트 해설"
     assert found_quiz["display_date"] == "2024-01-01"
 
     # 인증 없이는 접근 불가
@@ -317,6 +324,7 @@ def test_quiz_explanation_view_and_points(client, test_user, test_admin_user):
             "correct_answer": "헬멧",
             "answers": ["모자", "선글라스", "헬멧", "장갑"],
             "hint_link": "http://example.com/hint",
+            "explanation": "헬멧 착용 이유",
             "display_date": "2024-01-01",
         },
         headers=admin_headers,
@@ -324,17 +332,17 @@ def test_quiz_explanation_view_and_points(client, test_user, test_admin_user):
     assert res.status_code == 201
     quiz_id = res.get_json()["data"]["id"]
 
-    # 해설 추가 (실제 API가 있다면)
+    # 해설 업데이트
     with client.application.app_context():
         from app.db import get_db
 
         db = get_db()
         with db.cursor() as cur:
             cur.execute(
-                "INSERT INTO quiz_explanations (quiz_id, explanation) VALUES (%s, %s)",
+                "UPDATE quizzes SET explanation = %s WHERE id = %s",
                 (
-                    quiz_id,
                     "헬멧은 자전거 이용 시 머리를 보호하는 필수 안전 장비입니다.",
+                    quiz_id,
                 ),
             )
 
@@ -413,6 +421,7 @@ def test_quiz_correct_answer_points_only_once(client, test_user, test_admin_user
             "correct_answer": "정답",
             "answers": ["정답", "오답1", "오답2", "오답3"],
             "hint_link": "http://test_point_hint.com",
+            "explanation": "포인트 해설",
             "display_date": "2024-01-01",
         },
         headers=admin_headers,
@@ -472,6 +481,7 @@ def test_quiz_answers_array_support(client, test_admin_user):
         "correct_answer": "헬멧",
         "answers": ["헬멧", "무릎보호대", "반사조끼", "장갑"],
         "hint_link": "http://answers_hint.com",
+        "explanation": "정답은 헬멧",
         "display_date": "2024-01-01",
     }
     res = client.post(
@@ -486,6 +496,7 @@ def test_quiz_answers_array_support(client, test_admin_user):
     assert "헬멧" in data["answers"]
     assert "hint_link" in data
     assert data["hint_link"] == "http://answers_hint.com"
+    assert data["explanation"] == "정답은 헬멧"
     assert data["display_date"] == "2024-01-01"
 
 
@@ -513,6 +524,7 @@ def test_today_quiz_status(client, test_user, test_admin_user):
             "correct_answer": "정답",
             "answers": ["정답", "오답"],
             "hint_link": "http://hint.com",
+            "explanation": "오늘의 해설",
             "display_date": today,
         },
         headers=admin_headers,


### PR DESCRIPTION
### Description
- allow quizzes to store a text explanation
- update quiz APIs and swagger docs with the new field
- document schema and ERD changes
- adjust unit tests

### Testing Done
- `black . --line-length 88`
- `isort .`
- `mypy --strict .` *(failed: missing stubs)*
- `PYTHONPATH=. pytest -q` *(failed: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6884f9f6919c8321bb7d276676d9f7ea