### PR TITLE
fix(community): record comment rewards

### DIFF
--- a/app/routes/community.py
+++ b/app/routes/community.py
@@ -249,6 +249,41 @@ def create_post():
 
         cur.execute(
             """
+            SELECT id FROM rewards
+            WHERE user_id = %s AND source_type = 'post_comment' AND source_id = %s
+            """,
+            (user_id, comment["id"]),
+        )
+        if not cur.fetchone():
+            cur.execute(
+                """
+                INSERT INTO rewards
+                    (user_id, source_type, source_id, points, experience_points, reward_reason)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (user_id, "post_comment", comment["id"], 0, exp, "댓글 작성"),
+            )
+
+        # 보상 기록이 없으면 추가
+        cur.execute(
+            """
+            SELECT id FROM rewards
+            WHERE user_id = %s AND source_type = 'post_comment' AND source_id = %s
+            """,
+            (user_id, comment["id"]),
+        )
+        if not cur.fetchone():
+            cur.execute(
+                """
+                INSERT INTO rewards
+                    (user_id, source_type, source_id, points, experience_points, reward_reason)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (user_id, "post_comment", comment["id"], 0, exp, "댓글 작성"),
+            )
+
+        cur.execute(
+            """
             INSERT INTO rewards
             (user_id, source_type, source_id, points, experience_points, reward_reason)
             VALUES (%s, %s, %s, %s, %s, %s)
@@ -350,6 +385,22 @@ def create_comment(post_id):
             """,
             (exp, user_id),
         )
+        cur.execute(
+            """
+            SELECT id FROM rewards
+            WHERE user_id = %s AND source_type = 'post_comment' AND source_id = %s
+            """,
+            (user_id, comment["id"]),
+        )
+        if not cur.fetchone():
+            cur.execute(
+                """
+                INSERT INTO rewards
+                    (user_id, source_type, source_id, points, experience_points, reward_reason)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (user_id, "post_comment", comment["id"], 0, exp, "댓글 작성"),
+            )
 
     return make_response(dict(comment), 201)
 

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -73,6 +73,14 @@ def test_community_post_crud(client, test_user):
     )
     assert res.status_code == 201
 
+    # 댓글 작성 보상 확인
+    res = client.get("/users/rewards", headers=headers)
+    assert res.status_code == 200
+    rewards = res.get_json()["data"]
+    reasons = [r["reward_reason"] for r in rewards]
+    assert "게시글 작성" in reasons
+    assert "댓글 작성" in reasons
+
     # toggle like
     res = client.post(f"/community/posts/{post_id}/like", headers=headers)
     assert res.status_code == 200


### PR DESCRIPTION
### Description
- add reward record when creating a comment so experience logs are kept
- test that comment rewards are stored with the new reason field

### Testing Done
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_688ab19f47b4832191de0efa00f7743b