### PR TITLE
feat(recommendations): add admin notes to verification

### DIFF
--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -214,9 +214,43 @@ def verify_course_recommendation(rec_id: int):
               type: integer
               description: 승인 시 지급할 포인트
               example: 5
+            admin_notes:
+              type: string
+              description: 관리자 메모
+              example: "훌륭한 코스"
     responses:
       200:
         description: 코스 추천 검토 성공
+        schema:
+          type: object
+          properties:
+            code:
+              type: integer
+              example: 200
+            message:
+              type: string
+              example: "OK"
+            data:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  example: 1
+                user_id:
+                  type: integer
+                  example: 2
+                status:
+                  type: string
+                  example: verified
+                points_awarded:
+                  type: integer
+                  example: 5
+                admin_notes:
+                  type: string
+                  example: "훌륭한 코스"
+                reviewed_at:
+                  type: string
+                  example: "2024-01-01T10:00:00Z"
       400:
         description: 잘못된 요청
       401:
@@ -229,6 +263,7 @@ def verify_course_recommendation(rec_id: int):
     data = request.get_json() or {}
     status = data.get("status")
     points = data.get("points", 0)
+    admin_notes = data.get("admin_notes", "")
 
     if status not in ["verified", "rejected"]:
         return make_response({"error": "status must be 'verified' or 'rejected'"}, 400)
@@ -258,11 +293,18 @@ def verify_course_recommendation(rec_id: int):
             SET status = %s,
                 points_awarded = %s,
                 reviewed_by_admin_id = %s,
+                admin_notes = %s,
                 reviewed_at = CURRENT_TIMESTAMP
             WHERE id = %s
-            RETURNING id, status, points_awarded, reviewed_at
+            RETURNING id, user_id, status, points_awarded, admin_notes, reviewed_at
             """,
-            (status, points if status == "verified" else 0, admin_id, rec_id),
+            (
+                status,
+                points if status == "verified" else 0,
+                admin_id,
+                admin_notes,
+                rec_id,
+            ),
         )
         updated = cur.fetchone()
 

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -91,6 +91,20 @@ erDiagram
         timestamp created_at
     }
 
+    course_recommendations {
+        integer id PK
+        integer user_id FK
+        varchar location_name
+        varchar photo_url
+        text review
+        varchar status
+        integer points_awarded
+        integer reviewed_by_admin_id FK
+        text admin_notes
+        timestamp reviewed_at
+        timestamp created_at
+    }
+
     routes {
         integer id PK
         integer user_id FK
@@ -184,6 +198,8 @@ erDiagram
     users ||--o{ user_quiz_explanation_views : ""
     users ||--o{ bike_usage_logs : "creates"
     users ||--o{ bike_usage_logs : "verifies as admin"
+    users ||--o{ course_recommendations : "recommends"
+    users ||--o{ course_recommendations : "reviews as admin"
     users ||--o{ routes : ""
     users ||--o{ rewards : ""
     users ||--o{ community_posts : "writes"
@@ -246,6 +262,7 @@ erDiagram
 ### 7. 코스 추천 기능
 - **course_recommendations**: 사용자가 추천한 코스와 관리자 검토 내역을 관리합니다.
   - 사용자는 주 2회까지만 추천 가능
+  - 관리자 검토 시 admin_notes 기록 가능
 
 이 ERD는 앱 플로우의 실제 기능에 맞춰:
 

--- a/schema.sql
+++ b/schema.sql
@@ -250,6 +250,7 @@ CREATE TABLE course_recommendations (
     status VARCHAR(50) DEFAULT 'pending',
     points_awarded INTEGER DEFAULT 0,
     reviewed_by_admin_id INTEGER,
+    admin_notes TEXT,
     reviewed_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -116,13 +116,19 @@ def test_verify_recommendation(mock_upload, client, test_user, admin_user):
 
     res = client.post(
         f"/admin/course-recommendations/{rec_id}/verify",
-        json={"status": "approved", "points": 5},
+        json={
+            "status": "verified",
+            "points": 5,
+            "admin_notes": "좋은 코스",
+        },
         headers=admin_headers,
     )
     assert res.status_code == 200
     data = res.get_json()["data"][0]
-    assert data["status"] == "approved"
+    assert data["status"] == "verified"
     assert data["points_awarded"] == 5
+    assert data["admin_notes"] == "좋은 코스"
+    assert data["user_id"] == test_user
 
 
 @patch("app.routes.recommendations.upload_file_to_ncp")


### PR DESCRIPTION
### Description
- allow admins to include notes when verifying course recommendations
- return requesting user id alongside admin notes
- document `course_recommendations` admin_notes field in schema and ERD

### Testing Done
- `isort --profile black app/routes/recommendations.py tests/test_recommendations.py -c`
- `black app/routes/recommendations.py tests/test_recommendations.py`
- `flake8 app/routes/recommendations.py tests/test_recommendations.py` *(fails: command not found)*
- `mypy --strict app/routes/recommendations.py tests/test_recommendations.py` *(fails: numerous type errors and missing stubs)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68a479922888832198ebe60804d63b95