### PR TITLE
admin: show requester username in course recommendations

### DIFF
--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -344,7 +344,7 @@ def list_all_course_recommendations():
     tags:
       - Course Recommendations
     summary: 모든 코스 추천 목록 조회
-    description: 관리자가 제출된 모든 코스 추천을 최신순으로 조회합니다.
+    description: 관리자가 제출된 모든 코스 추천을 최신순으로 조회합니다. 각 추천에는 요청한 사용자의 username이 포함됩니다.
     security:
       - JWT: []
       - AdminHeader: []
@@ -376,8 +376,10 @@ def list_all_course_recommendations():
     with db.cursor() as cur:
         cur.execute(
             """
-            SELECT * FROM course_recommendations
-            ORDER BY created_at DESC
+            SELECT cr.*, u.username
+            FROM course_recommendations AS cr
+            JOIN users AS u ON cr.user_id = u.id
+            ORDER BY cr.created_at DESC
             LIMIT %s OFFSET %s
             """,
             (limit, offset),

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -199,6 +199,7 @@ def test_admin_list_all_recommendations(mock_upload, client, test_user, admin_us
     assert res.status_code == 200
     data = res.get_json()["data"]
     assert len(data) >= 1
+    assert any(rec["username"] == "testuser" for rec in data)
 
 
 def test_admin_list_requires_privileges(client, test_user):


### PR DESCRIPTION
### Description
- include submitting user's username in admin course recommendations list

### Testing Done
- `isort app/routes/recommendations.py tests/test_recommendations.py`
- `black app/routes/recommendations.py tests/test_recommendations.py`
- `flake8 app/routes/recommendations.py tests/test_recommendations.py` *(command not found)*
- `mypy --strict app/routes/recommendations.py tests/test_recommendations.py` *(errors: missing type annotations)*
- `PYTHONPATH=. pytest tests/test_recommendations.py::test_admin_list_all_recommendations -q` *(database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a492af38c08321867b30d97a6de4de