### PR TITLE
feat: flatten course recommendation points

### DIFF
--- a/app/routes/quizzes.py
+++ b/app/routes/quizzes.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from datetime import date, datetime
+from typing import Any, Dict, List, Sequence
 
 import aiohttp
 from flask import Blueprint, request
@@ -13,6 +14,53 @@ from ..utils.timezone import get_kst_today
 bp = Blueprint("quizzes", __name__)
 
 CLOVA_API_URL = "https://clovastudio.apigw.ntruss.com/testapp/v1/chat/completions"
+ALLOWED_QUIZ_TYPES = {"multiple_choice", "ox", "short_answer"}
+
+
+def _normalize_short_answer_payload(answers: Any, correct_answer: str) -> Dict[str, Any]:
+    if answers is None:
+        accepted_answers: List[str] = []
+        case_sensitive = False
+    elif isinstance(answers, dict):
+        accepted_answers = [
+            str(value)
+            for value in answers.get("accepted_answers", [])
+            if isinstance(value, str) and value.strip()
+        ]
+        case_sensitive = bool(answers.get("case_sensitive", False))
+    elif isinstance(answers, Sequence) and not isinstance(answers, (str, bytes)):
+        accepted_answers = [str(value) for value in answers if isinstance(value, str)]
+        case_sensitive = False
+    else:
+        raise ValueError("answers must be a list or object when quiz_type is 'short_answer'")
+
+    normalized_correct = correct_answer.strip()
+    if not normalized_correct:
+        raise ValueError("correct_answer required")
+
+    if normalized_correct not in accepted_answers:
+        accepted_answers.append(normalized_correct)
+
+    unique_answers = []
+    seen = set()
+    key_func = (lambda v: v if case_sensitive else v.casefold())
+    for value in accepted_answers:
+        key = key_func(value)
+        if key not in seen:
+            seen.add(key)
+            unique_answers.append(value)
+
+    return {"accepted_answers": unique_answers, "case_sensitive": case_sensitive}
+
+
+def _evaluate_short_answer(config: Dict[str, Any], answer: str) -> bool:
+    accepted = config.get("accepted_answers", []) if isinstance(config, dict) else []
+    case_sensitive = bool(config.get("case_sensitive", False)) if isinstance(config, dict) else False
+    submitted = answer.strip()
+    if not case_sensitive:
+        submitted_key = submitted.casefold()
+        return any(str(value).strip().casefold() == submitted_key for value in accepted)
+    return any(str(value).strip() == submitted for value in accepted)
 
 
 async def _generate_from_clova(prompt: str, api_key: str) -> dict:
@@ -62,6 +110,11 @@ def create_quiz():
               type: string
               description: 정답
               example: "헬멧"
+            quiz_type:
+              type: string
+              enum: [multiple_choice, ox, short_answer]
+              description: 퀴즈 유형
+              example: multiple_choice
             hint_link:
               type: string
               description: 힌트에 대한 사이트 링크
@@ -71,11 +124,7 @@ def create_quiz():
               description: 정답 해설
               example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
             answers:
-              type: array
-              description: 선택지 배열 (정답 포함)
-              items:
-                type: string
-              example: ["모자", "선글라스", "헬멧", "장갑"]
+              description: 객관식 보기 배열 혹은 단답형 허용 답안 JSON (예: {"accepted_answers": []})
             display_date:
               type: string
               format: date
@@ -97,26 +146,26 @@ def create_quiz():
               type: array
               items:
                 type: object
-                properties:
-                  id:
-                    type: integer
-                    example: 1
-                  question:
-                    type: string
-                    example: "자전거 안전을 위해 반드시 착용해야 하는 것은?"
-                  correct_answer:
-                    type: string
-                    example: "헬멧"
-                  hint_link:
-                    type: string
-                    example: "https://example.com/hint"
-                  answers:
-                    type: array
-                    items:
+                  properties:
+                    id:
+                      type: integer
+                      example: 1
+                    question:
                       type: string
-                    example: ["모자", "선글라스", "헬멧", "장갑"]
-                  display_date:
-                    type: string
+                      example: "자전거 안전을 위해 반드시 착용해야 하는 것은?"
+                    quiz_type:
+                      type: string
+                      example: multiple_choice
+                    correct_answer:
+                      type: string
+                      example: "헬멧"
+                    hint_link:
+                      type: string
+                      example: "https://example.com/hint"
+                    answers:
+                      description: 선택지 배열 또는 단답형 허용 답안 정의
+                    display_date:
+                      type: string
                     format: date
                     example: "2024-01-01"
       400:
@@ -128,8 +177,9 @@ def create_quiz():
     """
     data = request.get_json() or {}
     question = data.get("question")
-    correct_answer = data.get("correct_answer")
-    answers = data.get("answers", [])  # 선택지 배열
+    correct_answer = data.get("correct_answer", "")
+    quiz_type = data.get("quiz_type", "multiple_choice")
+    answers_payload = data.get("answers")
     hint_link = data.get("hint_link")
     explanation = data.get("explanation")
     display_date = data.get("display_date") or get_kst_today()
@@ -144,14 +194,55 @@ def create_quiz():
             except ValueError:
                 display_date = get_kst_today()
 
+    if quiz_type not in ALLOWED_QUIZ_TYPES:
+        return make_response(
+            {
+                "error": "quiz_type must be one of ['multiple_choice', 'ox', 'short_answer']"
+            },
+            400,
+        )
+
+    correct_answer = str(correct_answer).strip()
+
     if not question or not correct_answer:
         return make_response({"error": "question and correct_answer required"}, 400)
+
+    try:
+        if quiz_type == "multiple_choice":
+            if not isinstance(answers_payload, list) or len(answers_payload) < 2:
+                raise ValueError("answers must include at least two choices for multiple_choice quizzes")
+            normalized_answers = [str(value) for value in answers_payload]
+        elif quiz_type == "ox":
+            normalized_correct = correct_answer.upper()
+            if normalized_correct not in {"O", "X"}:
+                raise ValueError("correct_answer must be 'O' or 'X' for ox quizzes")
+            correct_answer = normalized_correct
+            options = ["O", "X"]
+            if isinstance(answers_payload, list) and {opt.upper() for opt in answers_payload} == {"O", "X"}:
+                options = [value.upper() for value in answers_payload]
+            normalized_answers = options
+        else:
+            normalized_answers = _normalize_short_answer_payload(answers_payload, correct_answer)
+    except ValueError as exc:
+        return make_response({"error": str(exc)}, 400)
 
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "INSERT INTO quizzes (question, correct_answer, answers, hint_link, explanation, display_date) VALUES (%s, %s, %s, %s, %s, %s) RETURNING id",
-            (question, correct_answer, answers, hint_link, explanation, display_date),
+            """
+            INSERT INTO quizzes (question, quiz_type, correct_answer, answers, hint_link, explanation, display_date)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                question,
+                quiz_type,
+                correct_answer,
+                normalized_answers,
+                hint_link,
+                explanation,
+                display_date,
+            ),
         )
         quiz_id = cur.fetchone()["id"]
 
@@ -161,7 +252,8 @@ def create_quiz():
             "question": question,
             "hint_link": hint_link,
             "correct_answer": correct_answer,
-            "answers": answers,
+            "quiz_type": quiz_type,
+            "answers": normalized_answers,
             "explanation": explanation,
             "display_date": display_date.isoformat(),
         },
@@ -275,24 +367,73 @@ def update_quiz(quiz_id):
     """
     data = request.get_json() or {}
     question = data.get("question")
-    correct_answer = data.get("correct_answer")
-    answers = data.get("answers", [])
+    correct_answer = data.get("correct_answer", "")
+    quiz_type = data.get("quiz_type") or "multiple_choice"
+    answers_payload = data.get("answers")
     hint_link = data.get("hint_link")
     explanation = data.get("explanation")
     if not question or not correct_answer:
         return make_response({"error": "question and correct_answer required"}, 400)
 
+    if quiz_type not in ALLOWED_QUIZ_TYPES:
+        return make_response(
+            {
+                "error": "quiz_type must be one of ['multiple_choice', 'ox', 'short_answer']"
+            },
+            400,
+        )
+
+    correct_answer = str(correct_answer).strip()
+
+    try:
+        if quiz_type == "multiple_choice":
+            if not isinstance(answers_payload, list) or len(answers_payload) < 2:
+                raise ValueError("answers must include at least two choices for multiple_choice quizzes")
+            normalized_answers = [str(value) for value in answers_payload]
+        elif quiz_type == "ox":
+            normalized_correct = correct_answer.upper()
+            if normalized_correct not in {"O", "X"}:
+                raise ValueError("correct_answer must be 'O' or 'X' for ox quizzes")
+            correct_answer = normalized_correct
+            options = ["O", "X"]
+            if isinstance(answers_payload, list) and {opt.upper() for opt in answers_payload} == {"O", "X"}:
+                options = [value.upper() for value in answers_payload]
+            normalized_answers = options
+        else:
+            normalized_answers = _normalize_short_answer_payload(answers_payload, correct_answer)
+    except ValueError as exc:
+        return make_response({"error": str(exc)}, 400)
+
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "UPDATE quizzes SET question = %s, correct_answer = %s, answers = %s, hint_link = %s, explanation = %s WHERE id = %s RETURNING id, question, correct_answer, answers, hint_link, explanation",
-            (question, correct_answer, answers, hint_link, explanation, quiz_id),
+            """
+            UPDATE quizzes
+            SET question = %s,
+                quiz_type = %s,
+                correct_answer = %s,
+                answers = %s,
+                hint_link = %s,
+                explanation = %s
+            WHERE id = %s
+            RETURNING id, question, quiz_type, correct_answer, answers, hint_link, explanation
+            """,
+            (
+                question,
+                quiz_type,
+                correct_answer,
+                normalized_answers,
+                hint_link,
+                explanation,
+                quiz_id,
+            ),
         )
         result = cur.fetchone()
         if not result:
             return make_response({"error": "quiz not found"}, 404)
 
-    return make_response(dict(result))
+    updated = dict(result)
+    return make_response(updated)
 
 
 @bp.route("/admin/quizzes/<int:quiz_id>", methods=["DELETE"])
@@ -396,7 +537,11 @@ def list_quizzes():
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "SELECT id, question, answers, hint_link, explanation, display_date FROM quizzes"
+            """
+            SELECT id, question, quiz_type, answers, hint_link, explanation, display_date
+            FROM quizzes
+            ORDER BY display_date DESC, id DESC
+            """
         )
         quizzes = cur.fetchall()
     for q in quizzes:
@@ -532,13 +677,17 @@ def attempt_quiz(quiz_id):
     user_id = get_current_user_id()
     data = request.get_json() or {}
     answer = data.get("answer")
-    if not answer:
+    if answer is None:
         return make_response({"error": "answer required"}, 400)
+    submitted_answer = str(answer)
 
     db = get_db()
     with db.cursor() as cur:
         # 퀴즈 정보 조회
-        cur.execute("SELECT correct_answer FROM quizzes WHERE id = %s", (quiz_id,))
+        cur.execute(
+            "SELECT quiz_type, correct_answer, answers FROM quizzes WHERE id = %s",
+            (quiz_id,),
+        )
         quiz = cur.fetchone()
         if not quiz:
             return make_response({"error": "quiz not found"}, 404)
@@ -553,7 +702,23 @@ def attempt_quiz(quiz_id):
         )
         already_correct = cur.fetchone()
 
-        is_correct = answer == quiz["correct_answer"]
+        quiz_type = quiz["quiz_type"]
+        correct_answer = quiz["correct_answer"]
+        answers_payload = quiz.get("answers")
+
+        if quiz_type == "multiple_choice":
+            is_correct = submitted_answer == correct_answer
+        elif quiz_type == "ox":
+            is_correct = submitted_answer.strip().upper() == correct_answer
+        else:
+            if isinstance(answers_payload, dict):
+                short_answer_config = answers_payload
+            else:
+                short_answer_config = _normalize_short_answer_payload(
+                    answers_payload,
+                    correct_answer,
+                )
+            is_correct = _evaluate_short_answer(short_answer_config, submitted_answer)
 
         # 시도 기록 저장
         cur.execute(
@@ -698,18 +863,51 @@ def generate_quiz():
 
     question = result.get("question")
     correct_answer = result.get("correct_answer")
+    answers_payload = result.get("answers")
+    quiz_type = result.get("quiz_type", "multiple_choice")
+
     if not question or not correct_answer:
         return make_response({"error": "invalid response from Clova X"}, 502)
+
+    if quiz_type not in ALLOWED_QUIZ_TYPES:
+        quiz_type = "multiple_choice"
+
+    correct_answer = str(correct_answer).strip()
+    if not correct_answer:
+        return make_response({"error": "invalid response from Clova X"}, 502)
+
+    try:
+        if quiz_type == "multiple_choice":
+            normalized_answers = answers_payload if isinstance(answers_payload, list) else []
+        elif quiz_type == "ox":
+            correct_answer = correct_answer.strip().upper()
+            normalized_answers = ["O", "X"]
+        else:
+            normalized_answers = _normalize_short_answer_payload(answers_payload, correct_answer)
+    except ValueError:
+        quiz_type = "multiple_choice"
+        normalized_answers = []
+        correct_answer = str(correct_answer)
 
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "INSERT INTO quizzes (question, correct_answer) VALUES (%s, %s) RETURNING id",
-            (question, correct_answer),
+            """
+            INSERT INTO quizzes (question, quiz_type, correct_answer, answers)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id
+            """,
+            (question, quiz_type, str(correct_answer), normalized_answers),
         )
         quiz_id = cur.fetchone()["id"]
 
     return make_response(
-        {"id": quiz_id, "question": question, "correct_answer": correct_answer},
+        {
+            "id": quiz_id,
+            "question": question,
+            "quiz_type": quiz_type,
+            "correct_answer": str(correct_answer),
+            "answers": normalized_answers,
+        },
         201,
     )

--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -1,5 +1,7 @@
 import csv
 import io
+import json
+from typing import Any, Dict, List
 
 from flask import Blueprint, Response, request
 
@@ -11,6 +13,200 @@ from .storage import upload_file_to_ncp
 bp = Blueprint("recommendations", __name__)
 
 
+MAX_POINTS_PER_COURSE = 5
+POINT_TYPES = {"start", "via", "finish"}
+
+
+def _clean_optional_text(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped if stripped else None
+    return value
+
+
+def _normalize_courses_payload(raw_payload: str) -> List[Dict[str, Any]]:
+    try:
+        payload = json.loads(raw_payload)
+    except (TypeError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+        raise ValueError("courses must be a valid JSON array") from exc
+
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("courses must be a non-empty array")
+
+    normalized_courses: List[Dict[str, Any]] = []
+    for course in payload:
+        if not isinstance(course, dict):
+            raise ValueError("each course must be an object")
+
+        label = str(course.get("label") or course.get("course_label") or "").strip()
+        if not label:
+            raise ValueError("course label is required")
+
+        points = course.get("points")
+        if not isinstance(points, list) or not points:
+            raise ValueError("each course must include at least a start and finish point")
+        if len(points) > MAX_POINTS_PER_COURSE:
+            raise ValueError(f"each course can include up to {MAX_POINTS_PER_COURSE} points")
+
+        normalized_points: List[Dict[str, Any]] = []
+        start_count = 0
+        finish_count = 0
+        for idx, point in enumerate(points, start=1):
+            if not isinstance(point, dict):
+                raise ValueError("each course point must be an object")
+            point_type = str(point.get("type") or point.get("point_type") or "").strip().lower()
+            if point_type not in POINT_TYPES:
+                raise ValueError("point type must be one of start, via, finish")
+            if point_type == "start":
+                start_count += 1
+            if point_type == "finish":
+                finish_count += 1
+
+            name = str(point.get("name") or "").strip()
+            if not name:
+                raise ValueError("point name is required")
+
+            address = _clean_optional_text(
+                point.get("address") or point.get("address_name")
+            )
+
+            description_value = point.get("description")
+            if description_value is None:
+                description_value = point.get("notes")
+            notes = _clean_optional_text(description_value)
+
+            photo_field_raw = point.get("photo_field") or point.get("photo_key")
+            photo_field = None
+            if photo_field_raw is not None:
+                photo_field = str(photo_field_raw).strip()
+                if not photo_field:
+                    raise ValueError("point photo_field cannot be empty when provided")
+
+            photo_url_raw = point.get("photo_url") or point.get("photo")
+            photo_url = None
+            if photo_url_raw is not None:
+                photo_url = str(photo_url_raw).strip()
+                if not photo_url:
+                    photo_url = None
+
+            normalized_points.append(
+                {
+                    "sequence_order": idx,
+                    "point_type": point_type,
+                    "name": name,
+                    "address": address,
+                    "latitude": point.get("latitude"),
+                    "longitude": point.get("longitude"),
+                    "notes": notes,
+                    "photo_field": photo_field,
+                    "photo_url": photo_url,
+                }
+            )
+
+        if start_count != 1 or finish_count != 1:
+            raise ValueError("each course must include exactly one start and one finish point")
+
+        normalized_courses.append(
+            {
+                "course_label": label,
+                "description": course.get("description"),
+                "distance_km": course.get("distance_km"),
+                "duration_minutes": course.get("duration_minutes"),
+                "difficulty_level": course.get("difficulty_level"),
+                "points": normalized_points,
+            }
+        )
+
+    return normalized_courses
+
+
+def _attach_courses(db, recommendations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not recommendations:
+        return []
+
+    recommendation_ids = [rec["id"] for rec in recommendations]
+    courses: Dict[int, List[Dict[str, Any]]] = {rec_id: [] for rec_id in recommendation_ids}
+    points: Dict[int, List[Dict[str, Any]]] = {}
+
+    with db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, recommendation_id, course_label, description, distance_km, duration_minutes, difficulty_level, created_at
+            FROM course_recommendation_courses
+            WHERE recommendation_id = ANY(%s)
+            ORDER BY created_at ASC, id ASC
+            """,
+            (recommendation_ids,),
+        )
+        course_rows = cur.fetchall()
+
+        course_ids = [row["id"] for row in course_rows]
+        for row in course_rows:
+            courses[row["recommendation_id"]].append(dict(row))
+
+        if course_ids:
+            cur.execute(
+                """
+                SELECT id, course_id, sequence_order, point_type, name, address, latitude, longitude, notes, photo_url
+                FROM course_recommendation_points
+                WHERE course_id = ANY(%s)
+                ORDER BY course_id ASC, sequence_order ASC
+                """,
+                (course_ids,),
+            )
+            for point_row in cur.fetchall():
+                points.setdefault(point_row["course_id"], []).append(dict(point_row))
+
+    for rec in recommendations:
+        rec_courses = []
+        for course in courses.get(rec["id"], []):
+            course_dict = dict(course)
+            course_dict["points"] = points.get(course_dict["id"], [])
+            rec_courses.append(course_dict)
+        rec["courses"] = rec_courses
+
+    return recommendations
+
+
+def _serialize_recommendation(rec: Dict[str, Any]) -> Dict[str, Any]:
+    base = dict(rec)
+    courses = base.pop("courses", [])
+
+    summary_value = base.pop("summary", None)
+    if summary_value is not None:
+        base["description"] = summary_value
+    else:
+        base["description"] = base.get("description")
+
+    flattened: List[Dict[str, Any]] = []
+    point_index = 0
+    for course in courses:
+        points = sorted(
+            course.get("points", []),
+            key=lambda p: (p.get("sequence_order") or 0, p.get("id") or 0),
+        )
+        for point in points:
+            flattened.append(
+                {
+                    "point_id": point_index,
+                    "name": point.get("name"),
+                    "address": point.get("address"),
+                    "description": point.get("notes"),
+                    "photo_url": point.get("photo_url"),
+                }
+            )
+            point_index += 1
+
+    base["courses"] = flattened
+    return base
+
+
+def _serialize_recommendations(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [_serialize_recommendation(record) for record in records]
+
+
 @bp.route("/users/course-recommendations", methods=["POST"])
 @jwt_required
 def create_course_recommendation():
@@ -20,29 +216,52 @@ def create_course_recommendation():
     tags:
       - Course Recommendations
     summary: 새로운 코스 추천 등록
-    description: |
-      코스 위치 이름과 후기를 입력하고 사진을 업로드하여 코스를 추천합니다.
-      코스 추천은 **주당 두 번**까지만 등록할 수 있습니다.
+      description: |
+        추천 묶음의 제목, 코스 요약, 최대 5개 지점을 포함한 루트 정보를 작성하고 사진을 업로드합니다.
+        코스 추천은 **주당 두 번**까지만 등록할 수 있습니다.
     security:
       - JWT: []
     consumes:
       - multipart/form-data
     parameters:
-      - in: formData
-        name: location_name
-        required: true
-        type: string
-        description: 코스 위치 이름
-      - in: formData
-        name: review
-        required: true
-        type: string
-        description: 코스 후기 내용
-      - in: formData
-        name: photo
-        required: true
-        type: file
-        description: 코스 사진 파일
+        - in: formData
+          name: title
+          required: true
+          type: string
+          description: 추천 묶음의 제목
+        - in: formData
+          name: description
+          required: false
+          type: string
+          description: 추천 요약. `summary`와 동일하게 처리됩니다.
+        - in: formData
+          name: summary
+          required: false
+          type: string
+          description: 추천 코스 요약
+        - in: formData
+          name: review
+          required: true
+          type: string
+          description: 코스 후기 내용
+        - in: formData
+          name: courses
+          required: true
+          type: string
+          description: |
+            JSON 배열 문자열. 각 코스는 label, description, points(출발/경유/도착 최대 5개)를 포함합니다.
+            각 point에는 선택적으로 `address`(지번/도로명), `description`(지점 설명), `photo_field`를 지정해 해당 이름의 form-data 파일을 업로드할 수 있습니다.
+          example: '[{"label": "A코스", "points": [{"type": "start", "name": "출발", "address": "서울시 영등포구", "description": "출발지", "photo_field": "point_photo_1"}, {"type": "finish", "name": "도착"}]}]'
+        - in: formData
+          name: photo
+          required: true
+          type: file
+          description: 코스 사진 파일
+        - in: formData
+          name: point_photo_*
+          required: false
+          type: file
+          description: 각 지점에 첨부할 사진 파일. `courses` JSON의 `photo_field` 이름과 일치해야 합니다.
     responses:
       201:
         description: 코스 추천 생성 성공
@@ -52,14 +271,42 @@ def create_course_recommendation():
         description: 인증 실패
     """
     user_id = get_current_user_id()
-    location_name = request.form.get("location_name")
+    title = request.form.get("title") or request.form.get("location_name")
+    summary = request.form.get("summary")
+    if summary is None:
+        summary = request.form.get("description")
     review = request.form.get("review")
+    courses_raw = request.form.get("courses")
 
-    if not location_name or not review:
-        return make_response({"error": "location_name and review required"}, 400)
+    if not title or not review:
+        return make_response({"error": "title and review required"}, 400)
+
+    if not courses_raw:
+        return make_response({"error": "courses payload required"}, 400)
+
+    try:
+        courses = _normalize_courses_payload(courses_raw)
+    except ValueError as exc:
+        return make_response({"error": str(exc)}, 400)
+
+    point_photo_fields = [
+        point["photo_field"]
+        for course in courses
+        for point in course["points"]
+        if point.get("photo_field")
+    ]
 
     if "photo" not in request.files:
         return make_response({"error": "photo required"}, 400)
+
+    missing_point_photos = [
+        field for field in set(point_photo_fields) if field not in request.files
+    ]
+    if missing_point_photos:
+        missing_list = ", ".join(sorted(missing_point_photos))
+        return make_response(
+            {"error": f"missing point photo files: {missing_list}"}, 400
+        )
 
     # 주 2회 제한
     db = get_db()
@@ -82,19 +329,105 @@ def create_course_recommendation():
     if error:
         return make_response({"error": f"photo upload failed: {error}"}, 500)
 
-    with db.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO course_recommendations
-                (user_id, location_name, photo_url, review)
-            VALUES (%s, %s, %s, %s)
-            RETURNING *
-            """,
-            (user_id, location_name, photo_url, review),
-        )
-        rec = cur.fetchone()
+    point_photo_urls: Dict[str, str] = {}
+    for field in sorted(set(point_photo_fields)):
+        point_photo = request.files.get(field)
+        if point_photo is None:  # pragma: no cover - guarded by earlier validation
+            continue
 
-    return make_response(dict(rec), 201)
+        uploaded_url, upload_error = upload_file_to_ncp(
+            point_photo, "course_recommendations/points"
+        )
+        if upload_error:
+            return make_response(
+                {"error": f"point photo upload failed: {upload_error}"}, 500
+            )
+        point_photo_urls[field] = uploaded_url
+
+    prev_autocommit = db.autocommit
+    db.autocommit = False
+    try:
+        with db.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO course_recommendations
+                    (user_id, title, summary, review, photo_url)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING *
+                """,
+                (user_id, title, summary, review, photo_url),
+            )
+            rec = dict(cur.fetchone())
+
+            inserted_courses: List[Dict[str, Any]] = []
+            for course in courses:
+                cur.execute(
+                    """
+                    INSERT INTO course_recommendation_courses
+                        (recommendation_id, course_label, description, distance_km, duration_minutes, difficulty_level)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    RETURNING *
+                    """,
+                    (
+                        rec["id"],
+                        course["course_label"],
+                        course.get("description"),
+                        course.get("distance_km"),
+                        course.get("duration_minutes"),
+                        course.get("difficulty_level"),
+                    ),
+                )
+                course_row = dict(cur.fetchone())
+
+                course_points: List[Dict[str, Any]] = []
+                for point in course["points"]:
+                    point_photo_url = point.get("photo_url")
+                    point_photo_field = point.get("photo_field")
+                    if point_photo_field:
+                        point_photo_url = point_photo_urls.get(point_photo_field)
+
+                    cur.execute(
+                        """
+                        INSERT INTO course_recommendation_points
+                            (course_id, sequence_order, point_type, name, address, latitude, longitude, notes, photo_url)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        RETURNING *
+                        """,
+                        (
+                            course_row["id"],
+                            point["sequence_order"],
+                            point["point_type"],
+                            point["name"],
+                            point.get("address"),
+                            point.get("latitude"),
+                            point.get("longitude"),
+                            point.get("notes"),
+                            point_photo_url,
+                        ),
+                    )
+                    course_points.append(dict(cur.fetchone()))
+
+                course_row["points"] = course_points
+                inserted_courses.append(course_row)
+
+            if photo_url:
+                cur.execute(
+                    """
+                    INSERT INTO course_recommendation_assets (recommendation_id, asset_type, url)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (rec["id"], "photo", photo_url),
+                )
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.autocommit = prev_autocommit
+
+    rec["courses"] = inserted_courses
+    return make_response(_serialize_recommendation(rec), 201)
 
 
 @bp.route("/users/course-recommendations", methods=["GET"])
@@ -126,8 +459,10 @@ def list_course_recommendations():
             """,
             (user_id,),
         )
-        rows = cur.fetchall()
-    return make_response([dict(row) for row in rows])
+        rows = [dict(row) for row in cur.fetchall()]
+
+    enriched = _attach_courses(db, rows)
+    return make_response(_serialize_recommendations(enriched))
 
 
 @bp.route("/users/course-recommendations/week/count", methods=["GET"])
@@ -384,9 +719,10 @@ def list_all_course_recommendations():
             """,
             (limit, offset),
         )
-        rows = cur.fetchall()
+        rows = [dict(row) for row in cur.fetchall()]
 
-    return make_response([dict(row) for row in rows])
+    enriched = _attach_courses(db, rows)
+    return make_response(_serialize_recommendations(enriched))
 
 
 @bp.route("/admin/course-recommendations/export", methods=["GET"])
@@ -428,9 +764,7 @@ def export_course_recommendations():
         if status:
             cur.execute(
                 """
-                SELECT cr.id, u.username, cr.location_name, cr.photo_url,
-                       cr.review, cr.status, cr.points_awarded,
-                       cr.reviewed_at, cr.created_at
+                SELECT cr.*, u.username
                 FROM course_recommendations cr
                 JOIN users u ON cr.user_id = u.id
                 WHERE cr.status = %s
@@ -441,9 +775,7 @@ def export_course_recommendations():
         else:
             cur.execute(
                 """
-                SELECT cr.id, u.username, cr.location_name, cr.photo_url,
-                       cr.review, cr.status, cr.points_awarded,
-                       cr.reviewed_at, cr.created_at
+                SELECT cr.*, u.username
                 FROM course_recommendations cr
                 JOIN users u ON cr.user_id = u.id
                 WHERE cr.status IN ('verified', 'rejected')
@@ -451,7 +783,9 @@ def export_course_recommendations():
                 """,
             )
 
-        rows = cur.fetchall()
+        rows = [dict(row) for row in cur.fetchall()]
+
+    enriched_rows = _attach_courses(db, rows)
 
     output = io.StringIO()
     writer = csv.writer(output)
@@ -459,23 +793,43 @@ def export_course_recommendations():
         [
             "id",
             "username",
-            "location_name",
+            "title",
+            "summary",
             "photo_url",
             "review",
+            "courses",
             "status",
             "points_awarded",
             "reviewed_at",
             "created_at",
         ]
     )
-    for row in rows:
+    for row in enriched_rows:
+        course_payload = []
+        for course in row.get("courses", []):
+            course_payload.append(
+                {
+                    "label": course.get("course_label"),
+                    "points": [
+                        {
+                            "order": point.get("sequence_order"),
+                            "type": point.get("point_type"),
+                            "name": point.get("name"),
+                        }
+                        for point in course.get("points", [])
+                    ],
+                }
+            )
+
         writer.writerow(
             [
                 row["id"],
                 row["username"],
-                row["location_name"],
+                row.get("title"),
+                row.get("summary"),
                 row["photo_url"],
                 row["review"],
+                json.dumps(course_payload, ensure_ascii=False),
                 row["status"],
                 row["points_awarded"],
                 row["reviewed_at"],

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -45,8 +45,9 @@ erDiagram
     quizzes {
         integer id PK
         string question
+        enum quiz_type
         string correct_answer
-        string[] answers
+        jsonb answers
         varchar hint_link
         text explanation
         date display_date
@@ -94,14 +95,48 @@ erDiagram
     course_recommendations {
         integer id PK
         integer user_id FK
-        varchar location_name
-        varchar photo_url
+        varchar title
+        text summary
         text review
+        varchar photo_url
         varchar status
         integer points_awarded
         integer reviewed_by_admin_id FK
         text admin_notes
         timestamp reviewed_at
+        timestamp created_at
+    }
+
+    course_recommendation_courses {
+        integer id PK
+        integer recommendation_id FK
+        varchar course_label
+        text description
+        decimal distance_km
+        integer duration_minutes
+        varchar difficulty_level
+        timestamp created_at
+    }
+
+    course_recommendation_points {
+        integer id PK
+        integer course_id FK
+        integer sequence_order
+        varchar point_type
+        varchar name
+        text address
+        decimal latitude
+        decimal longitude
+        text notes
+        text photo_url
+        timestamp created_at
+    }
+
+    course_recommendation_assets {
+        integer id PK
+        integer recommendation_id FK
+        varchar asset_type
+        text url
         timestamp created_at
     }
 
@@ -212,6 +247,10 @@ erDiagram
     quizzes ||--o{ quiz_explanations : "has"
     quizzes ||--o{ user_quiz_explanation_views : ""
 
+    course_recommendations ||--o{ course_recommendation_courses : "includes"
+    course_recommendation_courses ||--o{ course_recommendation_points : "visits"
+    course_recommendations ||--o{ course_recommendation_assets : "assets"
+
     routes ||--o{ route_points : "contains"
 
     community_posts ||--o{ post_comments : "has"
@@ -247,7 +286,7 @@ erDiagram
 
 ### 5. 게이미피케이션
 
-- **quizzes**: 퀴즈 문제 및 답안
+- **quizzes**: OX/객관식/단답형 등 다양한 유형의 퀴즈 문제와 채점 규칙
 - **user_quiz_attempts**: 사용자 퀴즈 시도 기록 (1회만 가능, 정답 시 포인트 지급)
 - **quiz_explanations**: 퀴즈 해설 (정답 시 보여지는 설명)
 - **user_quiz_explanation_views**: 해설 조회 기록 및 포인트 지급 관리 (한 번만 지급)
@@ -260,7 +299,10 @@ erDiagram
 - **user_settings**: 개인 설정 (알림, 프라이버시 등)
 
 ### 7. 코스 추천 기능
-- **course_recommendations**: 사용자가 추천한 코스와 관리자 검토 내역을 관리합니다.
+- **course_recommendations**: 추천 묶음의 메타데이터(제목, 요약, 후기, 검토 상태) 관리
+- **course_recommendation_courses**: 하나의 추천 묶음 안에 포함된 개별 루트 정보
+- **course_recommendation_points**: 각 루트의 출발·경유·도착 지점 (최대 5개, 지점별 `address`·`notes`(지점 설명)·`photo_url` 보관)
+- **course_recommendation_assets**: 추천에 첨부된 사진, GPX 등 추가 자료
   - 사용자는 주 2회까지만 추천 가능
   - 관리자 검토 시 admin_notes 기록 가능
 

--- a/schema.sql
+++ b/schema.sql
@@ -20,7 +20,11 @@ DROP TABLE IF EXISTS quizzes CASCADE;
 DROP TABLE IF EXISTS news CASCADE;
 DROP TABLE IF EXISTS user_levels CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS course_recommendation_points CASCADE;
+DROP TABLE IF EXISTS course_recommendation_courses CASCADE;
+DROP TABLE IF EXISTS course_recommendation_assets CASCADE;
 DROP TABLE IF EXISTS course_recommendations CASCADE;
+DROP TYPE IF EXISTS quiz_type_enum;
 
 CREATE TABLE user_levels (
     level INTEGER PRIMARY KEY,
@@ -67,12 +71,14 @@ CREATE TABLE user_verifications (
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
+CREATE TYPE quiz_type_enum AS ENUM ('multiple_choice', 'ox', 'short_answer');
+
 CREATE TABLE quizzes (
     id SERIAL PRIMARY KEY,
     question TEXT NOT NULL,
-    quizzes_type VARCHAR(100) NOT NULL, -- OX, 객관식, 단답식
+    quiz_type quiz_type_enum NOT NULL DEFAULT 'multiple_choice',
     correct_answer TEXT NOT NULL,
-    answers TEXT[],
+    answers JSONB DEFAULT '[]'::jsonb,
     hint_link VARCHAR(512),
     explanation TEXT,
     display_date DATE DEFAULT CURRENT_DATE,
@@ -246,8 +252,10 @@ CREATE TABLE safety_reports (
 CREATE TABLE course_recommendations (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL,
-    course_name VARCHAR(255) NOT NULL,
-    description TEXT,
+    title VARCHAR(255) NOT NULL,
+    summary TEXT,
+    review TEXT,
+    photo_url TEXT,
     status VARCHAR(50) DEFAULT 'pending',
     points_awarded INTEGER DEFAULT 0,
     reviewed_by_admin_id INTEGER,
@@ -258,14 +266,41 @@ CREATE TABLE course_recommendations (
     FOREIGN KEY (reviewed_by_admin_id) REFERENCES users (id) ON DELETE SET NULL
 );
 
-CREATE TABLE course_waypoints (
+CREATE TABLE course_recommendation_courses (
+    id SERIAL PRIMARY KEY,
+    recommendation_id INTEGER NOT NULL,
+    course_label VARCHAR(50) NOT NULL,
+    description TEXT,
+    distance_km DECIMAL(6, 2),
+    duration_minutes INTEGER,
+    difficulty_level VARCHAR(50),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (recommendation_id) REFERENCES course_recommendations (id) ON DELETE CASCADE
+);
+
+CREATE TABLE course_recommendation_points (
     id SERIAL PRIMARY KEY,
     course_id INTEGER NOT NULL,
     sequence_order INTEGER NOT NULL,
-    waypoint_name VARCHAR(255) NOT NULL,
-    description TEXT,
+    point_type VARCHAR(10) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    address TEXT,
+    latitude DECIMAL(9, 6),
+    longitude DECIMAL(9, 6),
+    notes TEXT,
+    photo_url TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (course_id) REFERENCES course_recommendations (id) ON DELETE CASCADE
+    FOREIGN KEY (course_id) REFERENCES course_recommendation_courses (id) ON DELETE CASCADE,
+    CONSTRAINT course_points_sequence_check CHECK (sequence_order BETWEEN 1 AND 5)
+);
+
+CREATE TABLE course_recommendation_assets (
+    id SERIAL PRIMARY KEY,
+    recommendation_id INTEGER NOT NULL,
+    asset_type VARCHAR(50) NOT NULL,
+    url TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (recommendation_id) REFERENCES course_recommendations (id) ON DELETE CASCADE
 );
 
 -- 즐겨찾기

--- a/tests/test_quizzes.py
+++ b/tests/test_quizzes.py
@@ -166,6 +166,82 @@ def test_user_attempt_quiz(client, test_user, test_admin_user):
     assert res.get_json()["data"]["is_correct"] is False
 
 
+def test_ox_quiz_attempt(client, test_user, test_admin_user):
+    admin_headers = get_admin_headers(
+        get_admin_jwt_token(test_admin_user, "admin", "admin@example.com")
+    )
+    user_headers = get_auth_headers(
+        get_test_jwt_token(test_user, "testuser", "test@example.com")
+    )
+
+    res = client.post(
+        "/admin/quizzes",
+        json={
+            "question": "안전모를 써야 한다",
+            "quiz_type": "ox",
+            "correct_answer": "O",
+            "answers": ["O", "X"],
+            "explanation": "안전모는 필수입니다.",
+        },
+        headers=admin_headers,
+    )
+    quiz_id = res.get_json()["data"]["id"]
+
+    res = client.post(
+        f"/quizzes/{quiz_id}/attempt",
+        json={"answer": "o"},
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    assert res.get_json()["data"]["is_correct"] is True
+
+    res = client.post(
+        f"/quizzes/{quiz_id}/attempt",
+        json={"answer": "X"},
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    assert res.get_json()["data"]["is_correct"] is False
+
+
+def test_short_answer_quiz_attempt(client, test_user, test_admin_user):
+    admin_headers = get_admin_headers(
+        get_admin_jwt_token(test_admin_user, "admin", "admin@example.com")
+    )
+    user_headers = get_auth_headers(
+        get_test_jwt_token(test_user, "testuser", "test@example.com")
+    )
+
+    res = client.post(
+        "/admin/quizzes",
+        json={
+            "question": "자전거 필수 장비는?",
+            "quiz_type": "short_answer",
+            "correct_answer": "헬멧",
+            "answers": {"accepted_answers": ["helmet", "헬 멧"], "case_sensitive": False},
+            "explanation": "헬멧을 착용해야 합니다.",
+        },
+        headers=admin_headers,
+    )
+    quiz_id = res.get_json()["data"]["id"]
+
+    res = client.post(
+        f"/quizzes/{quiz_id}/attempt",
+        json={"answer": "Helmet"},
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    assert res.get_json()["data"]["is_correct"] is True
+
+    res = client.post(
+        f"/quizzes/{quiz_id}/attempt",
+        json={"answer": "장갑"},
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    assert res.get_json()["data"]["is_correct"] is False
+
+
 def test_list_quizzes(client, test_user, test_admin_user):
     """퀴즈 목록 조회 테스트 (JWT 인증 필요) - answers와 hint_link 포함 확인"""
     admin_headers = get_admin_headers(

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,4 +1,5 @@
 import io
+import json
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,41 @@ def app():
 @pytest.fixture
 def client(app):
     return app.test_client()
+
+
+def _courses_payload(
+    label: str = "A코스",
+    include_point_photos: bool = False,
+    include_address: bool = False,
+    include_point_descriptions: bool = False,
+) -> str:
+    points = [
+        {"type": "start", "name": "출발지"},
+        {"type": "finish", "name": "도착지"},
+    ]
+
+    if include_point_photos:
+        for idx, point in enumerate(points, start=1):
+            point["photo_field"] = f"point_photo_{idx}"
+
+    if include_address:
+        for idx, point in enumerate(points, start=1):
+            point["address"] = f"서울시 테스트구 {idx}번지"
+
+    if include_point_descriptions:
+        for idx, point in enumerate(points, start=1):
+            point["description"] = f"지점 설명 {idx}"
+
+    return json.dumps(
+        [
+            {
+                "label": label,
+                "description": "기본 코스",
+                "points": points,
+            }
+        ],
+        ensure_ascii=False,
+    )
 
 
 @pytest.fixture
@@ -62,30 +98,66 @@ def create_fake_image():
 
 @patch("app.routes.recommendations.upload_file_to_ncp")
 def test_create_and_list_recommendations(mock_upload, client, test_user):
-    mock_upload.return_value = ("https://test.com/photo.jpg", None)
+    mock_upload.side_effect = [
+        ("https://test.com/photo.jpg", None),
+        ("https://test.com/point_start.jpg", None),
+        ("https://test.com/point_finish.jpg", None),
+    ]
     token = get_test_jwt_token(
         test_user, f"user_{test_user}", f"user{test_user}@example.com"
     )
     headers = get_auth_headers(token)
 
-    img, _ = create_fake_image()
+    route_photo = (io.BytesIO(b"route"), "photo.jpg")
+    start_photo = (io.BytesIO(b"start"), "start.jpg")
+    finish_photo = (io.BytesIO(b"finish"), "finish.jpg")
     res = client.post(
         "/users/course-recommendations",
         data={
-            "location_name": "한강",
+            "title": "한강",
+            "description": "설명",
             "review": "멋진 코스",
-            "photo": (img, "photo.jpg"),
+            "courses": _courses_payload(
+                "한강 코스",
+                include_point_photos=True,
+                include_address=True,
+                include_point_descriptions=True,
+            ),
+            "photo": route_photo,
+            "point_photo_1": start_photo,
+            "point_photo_2": finish_photo,
         },
         headers=headers,
         content_type="multipart/form-data",
     )
     assert res.status_code == 201
+    created = res.get_json()["data"][0]
+    created_points = created["courses"]
+    assert created_points[0]["point_id"] == 0
+    assert created_points[1]["point_id"] == 1
+    assert created_points[0]["photo_url"] == "https://test.com/point_start.jpg"
+    assert created_points[1]["photo_url"] == "https://test.com/point_finish.jpg"
+    assert created_points[0]["address"] == "서울시 테스트구 1번지"
+    assert created_points[1]["address"] == "서울시 테스트구 2번지"
+    assert created_points[0]["description"] == "지점 설명 1"
+    assert created_points[1]["description"] == "지점 설명 2"
 
     res = client.get("/users/course-recommendations", headers=headers)
     assert res.status_code == 200
     data = res.get_json()["data"]
     assert len(data) == 1
-    assert data[0]["location_name"] == "한강"
+    assert data[0]["title"] == "한강"
+    assert data[0]["description"] == "설명"
+    assert len(data[0]["courses"]) == 2
+    list_points = data[0]["courses"]
+    assert list_points[0]["point_id"] == 0
+    assert list_points[1]["point_id"] == 1
+    assert list_points[0]["photo_url"] == "https://test.com/point_start.jpg"
+    assert list_points[1]["photo_url"] == "https://test.com/point_finish.jpg"
+    assert list_points[0]["address"] == "서울시 테스트구 1번지"
+    assert list_points[1]["address"] == "서울시 테스트구 2번지"
+    assert list_points[0]["description"] == "지점 설명 1"
+    assert list_points[1]["description"] == "지점 설명 2"
 
 
 @patch("app.routes.recommendations.upload_file_to_ncp")
@@ -100,8 +172,9 @@ def test_verify_recommendation(mock_upload, client, test_user, admin_user):
     res = client.post(
         "/users/course-recommendations",
         data={
-            "location_name": "한강",
+            "title": "한강",
             "review": "멋진 코스",
+            "courses": _courses_payload("한강 코스", include_address=True),
             "photo": (img, "photo.jpg"),
         },
         headers=user_headers,
@@ -144,8 +217,9 @@ def test_weekly_recommendation_limit(mock_upload, client, test_user):
         res = client.post(
             "/users/course-recommendations",
             data={
-                "location_name": f"코스{i}",
+                "title": f"코스{i}",
                 "review": "굿",
+                "courses": _courses_payload(f"코스{i} 루트"),
                 "photo": (img, f"p{i}.jpg"),
             },
             headers=headers,
@@ -157,8 +231,9 @@ def test_weekly_recommendation_limit(mock_upload, client, test_user):
     res = client.post(
         "/users/course-recommendations",
         data={
-            "location_name": "코스3",
+            "title": "코스3",
             "review": "굿",
+            "courses": _courses_payload("코스3 루트"),
             "photo": (img, "p3.jpg"),
         },
         headers=headers,
@@ -182,8 +257,9 @@ def test_admin_list_all_recommendations(mock_upload, client, test_user, admin_us
     client.post(
         "/users/course-recommendations",
         data={
-            "location_name": "한강",
+            "title": "한강",
             "review": "멋진 코스",
+            "courses": _courses_payload("한강 코스"),
             "photo": (img, "photo.jpg"),
         },
         headers=user_headers,
@@ -220,7 +296,7 @@ def test_admin_course_recommendations_pagination(client, app, admin_user, test_u
             cur.execute("DELETE FROM course_recommendations")
             for i in range(3):
                 cur.execute(
-                    "INSERT INTO course_recommendations (user_id, location_name, review) VALUES (%s, %s, %s)",
+                    "INSERT INTO course_recommendations (user_id, title, review) VALUES (%s, %s, %s)",
                     (test_user, f"장소{i}", f"리뷰{i}"),
                 )
 
@@ -231,7 +307,7 @@ def test_admin_course_recommendations_pagination(client, app, admin_user, test_u
     assert res.status_code == 200
     data = res.get_json()["data"]
     assert len(data) == 1
-    assert data[0]["location_name"] == "장소1"
+    assert data[0]["title"] == "장소1"
 
 
 @patch("app.routes.recommendations.upload_file_to_ncp")
@@ -250,8 +326,9 @@ def test_week_recommendation_count(mock_upload, client, test_user):
     client.post(
         "/users/course-recommendations",
         data={
-            "location_name": "한강",
+            "title": "한강",
             "review": "굿",
+            "courses": _courses_payload("한강 루트"),
             "photo": (img, "p.jpg"),
         },
         headers=headers,
@@ -268,11 +345,11 @@ def test_export_course_recommendations_csv(client, app, test_user):
         db = get_db()
         with db.cursor() as cur:
             cur.execute(
-                "INSERT INTO course_recommendations (user_id, location_name, review, status) VALUES (%s, %s, %s, %s)",
+                "INSERT INTO course_recommendations (user_id, title, review, status) VALUES (%s, %s, %s, %s)",
                 (test_user, "한강", "굿", "verified"),
             )
             cur.execute(
-                "INSERT INTO course_recommendations (user_id, location_name, review, status) VALUES (%s, %s, %s, %s)",
+                "INSERT INTO course_recommendations (user_id, title, review, status) VALUES (%s, %s, %s, %s)",
                 (test_user, "잠실", "보통", "pending"),
             )
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -410,10 +410,10 @@ def test_admin_get_user_activities(client, app):
 
             cur.execute(
                 """
-                INSERT INTO quizzes (question, correct_answer, answers)
-                VALUES (%s, %s, %s) RETURNING id
+                INSERT INTO quizzes (question, quiz_type, correct_answer, answers)
+                VALUES (%s, %s, %s, %s) RETURNING id
                 """,
-                ("Q1", "A", ["A", "B"]),
+                ("Q1", "multiple_choice", "A", ["A", "B"]),
             )
             quiz_id = cur.fetchone()["id"]
 


### PR DESCRIPTION
### Description
- flatten course recommendation payloads into a single ordered list of waypoint details including addresses, descriptions, and photos
- accept top-level description aliases and persist per-point descriptions when normalizing uploaded course data
- refresh documentation and tests to cover the new representation for course recommendation responses

### Testing Done
- PYTHONPATH=. pytest tests/test_recommendations.py -k create --maxfail=1 *(fails: connection to local PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_68f60a6407708321b777b4764b2eaa1c