### PR TITLE
fix(swagger): correct YAML docstrings for specs

### DIFF
--- a/app/routes/quizzes.py
+++ b/app/routes/quizzes.py
@@ -124,7 +124,25 @@ def create_quiz():
               description: 정답 해설
               example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
             answers:
-              description: 객관식 보기 배열 혹은 단답형 허용 답안 JSON (예: {"accepted_answers": []})
+              description: >-
+                객관식 보기 배열 또는 단답형 허용 답안 정의.
+                단답형은 {"accepted_answers": [...], "case_sensitive": false}
+                형식을 사용합니다.
+              oneOf:
+                - type: array
+                  items:
+                    type: string
+                  example: ["헬멧", "모자", "장갑"]
+                - type: object
+                  properties:
+                    accepted_answers:
+                      type: array
+                      items:
+                        type: string
+                      example: ["헬멧"]
+                    case_sensitive:
+                      type: boolean
+                      example: false
             display_date:
               type: string
               format: date
@@ -146,26 +164,32 @@ def create_quiz():
               type: array
               items:
                 type: object
-                  properties:
-                    id:
-                      type: integer
-                      example: 1
-                    question:
-                      type: string
-                      example: "자전거 안전을 위해 반드시 착용해야 하는 것은?"
-                    quiz_type:
-                      type: string
-                      example: multiple_choice
-                    correct_answer:
-                      type: string
-                      example: "헬멧"
-                    hint_link:
-                      type: string
-                      example: "https://example.com/hint"
-                    answers:
-                      description: 선택지 배열 또는 단답형 허용 답안 정의
-                    display_date:
-                      type: string
+                properties:
+                  id:
+                    type: integer
+                    example: 1
+                  question:
+                    type: string
+                    example: "자전거 안전을 위해 반드시 착용해야 하는 것은?"
+                  quiz_type:
+                    type: string
+                    example: multiple_choice
+                  correct_answer:
+                    type: string
+                    example: "헬멧"
+                  hint_link:
+                    type: string
+                    example: "https://example.com/hint"
+                  explanation:
+                    type: string
+                    example: "헬멧은 머리를 보호하기 위한 필수 장비입니다."
+                  answers:
+                    description: >-
+                      선택지 배열 또는 단답형 허용 답안 정의.
+                      단답형은 {"accepted_answers": [...], "case_sensitive": false}
+                      형식을 사용합니다.
+                  display_date:
+                    type: string
                     format: date
                     example: "2024-01-01"
       400:

--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -216,52 +216,55 @@ def create_course_recommendation():
     tags:
       - Course Recommendations
     summary: 새로운 코스 추천 등록
-      description: |
-        추천 묶음의 제목, 코스 요약, 최대 5개 지점을 포함한 루트 정보를 작성하고 사진을 업로드합니다.
-        코스 추천은 **주당 두 번**까지만 등록할 수 있습니다.
+    description: |
+      추천 묶음의 제목, 코스 요약, 최대 5개 지점을 포함한 루트 정보를 작성하고 사진을 업로드합니다.
+      코스 추천은 **주당 두 번**까지만 등록할 수 있습니다.
     security:
       - JWT: []
     consumes:
       - multipart/form-data
     parameters:
-        - in: formData
-          name: title
-          required: true
-          type: string
-          description: 추천 묶음의 제목
-        - in: formData
-          name: description
-          required: false
-          type: string
-          description: 추천 요약. `summary`와 동일하게 처리됩니다.
-        - in: formData
-          name: summary
-          required: false
-          type: string
-          description: 추천 코스 요약
-        - in: formData
-          name: review
-          required: true
-          type: string
-          description: 코스 후기 내용
-        - in: formData
-          name: courses
-          required: true
-          type: string
-          description: |
-            JSON 배열 문자열. 각 코스는 label, description, points(출발/경유/도착 최대 5개)를 포함합니다.
-            각 point에는 선택적으로 `address`(지번/도로명), `description`(지점 설명), `photo_field`를 지정해 해당 이름의 form-data 파일을 업로드할 수 있습니다.
-          example: '[{"label": "A코스", "points": [{"type": "start", "name": "출발", "address": "서울시 영등포구", "description": "출발지", "photo_field": "point_photo_1"}, {"type": "finish", "name": "도착"}]}]'
-        - in: formData
-          name: photo
-          required: true
-          type: file
-          description: 코스 사진 파일
-        - in: formData
-          name: point_photo_*
-          required: false
-          type: file
-          description: 각 지점에 첨부할 사진 파일. `courses` JSON의 `photo_field` 이름과 일치해야 합니다.
+      - in: formData
+        name: title
+        required: true
+        type: string
+        description: 추천 묶음의 제목
+      - in: formData
+        name: description
+        required: false
+        type: string
+        description: 추천 요약. `summary`와 동일하게 처리됩니다.
+      - in: formData
+        name: summary
+        required: false
+        type: string
+        description: 추천 코스 요약
+      - in: formData
+        name: review
+        required: true
+        type: string
+        description: 코스 후기 내용
+      - in: formData
+        name: courses
+        required: true
+        type: string
+        description: |
+          JSON 배열 문자열. 각 코스는 label, description,
+          points(출발/경유/도착 최대 5개)를 포함합니다.
+          각 point에는 선택적으로 `address`(지번/도로명),
+          `description`(지점 설명), `photo_field`를 지정해 해당 이름의
+          form-data 파일을 업로드할 수 있습니다.
+        example: '[{"label": "A코스", "points": [{"type": "start", "name": "출발", "address": "서울시 영등포구", "description": "출발지", "photo_field": "point_photo_1"}, {"type": "finish", "name": "도착"}]}]'
+      - in: formData
+        name: photo
+        required: true
+        type: file
+        description: 코스 사진 파일
+      - in: formData
+        name: point_photo_*
+        required: false
+        type: file
+        description: 각 지점에 첨부할 사진 파일. `courses` JSON의 `photo_field` 이름과 일치해야 합니다.
     responses:
       201:
         description: 코스 추천 생성 성공


### PR DESCRIPTION
### Description
- fix the quiz creation Swagger docstring so the answers schema is valid YAML
- correct the course recommendation upload docstring indentation so the generated spec parses successfully

### Testing Done
- Not run (database connection required in the current environment)


------
https://chatgpt.com/codex/tasks/task_e_68f9c5d192208321a9ea6ba62f73e05a