### PR TITLE
fix(recommendations): align weekly reset with kst sunday

### DIFF
--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -8,6 +8,7 @@ from flask import Blueprint, Response, request
 from ..db import get_db
 from ..utils.auth import admin_required, get_current_user_id, jwt_required
 from ..utils.responses import make_response
+from ..utils.timezone import get_kst_week_start_for_sunday_reset
 from .storage import upload_file_to_ncp
 
 bp = Blueprint("recommendations", __name__)
@@ -285,15 +286,16 @@ def create_course_recommendation():
     except ValueError as exc:
         return make_response({"error": str(exc)}, 400)
 
-    # 주 2회 제한
+    # 주 2회 제한 (일요일 00:00 KST 기준으로 초기화)
     db = get_db()
+    week_start_utc = get_kst_week_start_for_sunday_reset()
     with db.cursor() as cur:
         cur.execute(
             "SELECT COUNT(*) as count FROM course_recommendations"
             " WHERE user_id = %s"
-            " AND created_at >= date_trunc('week', CURRENT_DATE)"
+            " AND created_at >= %s"
             " AND status != 'rejected'",
-            (user_id,),
+            (user_id, week_start_utc),
         )
         result = cur.fetchone()
         if result and result["count"] >= 2:

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -46,3 +46,29 @@ def get_kst_date_range_for_today():
     end_of_day_utc = end_of_day_kst.astimezone(timezone.utc)
     
     return start_of_day_utc, end_of_day_utc
+
+
+def get_kst_week_start_for_sunday_reset(reference: datetime | None = None) -> datetime:
+    """
+    한국 시간(KST) 기준으로 일요일 00:00에 초기화되는 주간 시작 시각을 UTC로 반환합니다.
+
+    Args:
+        reference: 기준이 되는 시각. 지정하지 않으면 현재 UTC 시간을 사용합니다.
+
+    Returns:
+        datetime: 기준 시각이 속한 주의 시작(일요일 00:00 KST)을 UTC 시간으로 변환한 값.
+    """
+
+    if reference is None:
+        reference = datetime.now(timezone.utc)
+    elif reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+
+    kst_now = reference.astimezone(KST)
+    kst_midnight = (
+        datetime.combine(kst_now.date(), datetime.min.time())
+        .replace(tzinfo=KST)
+    )
+    days_since_sunday = (kst_midnight.weekday() + 1) % 7
+    week_start_kst = kst_midnight - timedelta(days=days_since_sunday)
+    return week_start_kst.astimezone(timezone.utc)

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+from app.utils.timezone import (
+    KST,
+    get_kst_week_start_for_sunday_reset,
+    utc_datetime_to_kst,
+)
+
+
+def test_week_start_returns_sunday_midnight_for_midweek_reference():
+    reference = datetime(2024, 7, 10, 12, 0, tzinfo=timezone.utc)
+
+    week_start_utc = get_kst_week_start_for_sunday_reset(reference)
+    week_start_kst = utc_datetime_to_kst(week_start_utc)
+
+    assert week_start_kst.tzinfo == KST
+    assert week_start_kst.weekday() == 6  # Sunday
+    assert week_start_kst.hour == 0
+    assert week_start_kst.minute == 0
+    assert week_start_kst.second == 0
+    assert week_start_kst.date().isoformat() == "2024-07-07"
+
+
+def test_week_start_handles_sunday_reference_correctly():
+    reference = datetime(2024, 7, 7, 3, 0, tzinfo=timezone.utc)
+
+    week_start_utc = get_kst_week_start_for_sunday_reset(reference)
+    week_start_kst = utc_datetime_to_kst(week_start_utc)
+
+    assert week_start_kst.tzinfo == KST
+    assert week_start_kst.date().isoformat() == "2024-07-07"
+    assert week_start_kst.hour == 0
+    assert week_start_kst.minute == 0
+    assert week_start_kst.second == 0


### PR DESCRIPTION
### Description
- compute the weekly reset boundary in Python so that course recommendation limits restart at Sunday 00:00 KST
- add a timezone utility that returns the Sunday-start week boundary and update the recommendations route to use it
- cover the new timezone helper with unit tests to ensure the cutoff aligns with Sunday midnight in KST

### Testing Done
- `PYTHONPATH=. pytest -q` *(fails: cannot connect to PostgreSQL on localhost:5432 in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_69056cd348b08321847bec685a645a6e