### PR TITLE
fix(recommendations): reset weekly limit on server sunday

### DIFF
--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -285,13 +285,13 @@ def create_course_recommendation():
     except ValueError as exc:
         return make_response({"error": str(exc)}, 400)
 
-    # 주 2회 제한
+    # 주 2회 제한 (서버 시간 기준 일요일 00:00에 초기화)
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
             "SELECT COUNT(*) as count FROM course_recommendations"
             " WHERE user_id = %s"
-            " AND created_at >= date_trunc('week', CURRENT_DATE)"
+            " AND created_at >= date_trunc('week', CURRENT_TIMESTAMP + INTERVAL '1 day') - INTERVAL '1 day'"
             " AND status != 'rejected'",
             (user_id,),
         )
@@ -479,7 +479,8 @@ def week_course_recommendation_count():
     with db.cursor() as cur:
         cur.execute(
             "SELECT COUNT(*) as count FROM course_recommendations "
-            "WHERE user_id = %s AND created_at >= date_trunc('week', CURRENT_DATE) "
+            "WHERE user_id = %s "
+            "AND created_at >= date_trunc('week', CURRENT_TIMESTAMP + INTERVAL '1 day') - INTERVAL '1 day' "
             "AND status != 'rejected'",
             (user_id,),
         )

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -46,3 +46,5 @@ def get_kst_date_range_for_today():
     end_of_day_utc = end_of_day_kst.astimezone(timezone.utc)
     
     return start_of_day_utc, end_of_day_utc
+
+


### PR DESCRIPTION
### Description
- reset the weekly course recommendation quota using the database server's Sunday 00:00 boundary via SQL date arithmetic
- remove the unused KST Sunday reset helper and its tests that are no longer required

### Testing Done
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_69056cd348b08321847bec685a645a6e