### PR TITLE
fix: accept admin bike log photos as data urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Swagger UI를 통해 모든 API를 손쉽게 테스트할 수 있습니다.
 - **코스 추천**: 주 2회만 등록 가능
   - 이번 주 몇 회 등록했는지 확인하려면 `/users/course-recommendations/week/count` 엔드포인트를 호출합니다.
 
+### 관리자 자전거 활동 등록
+
+- **신규 관리자 엔드포인트**: `POST /admin/users/{user_id}/bike-logs`
+  - 관리자는 특정 사용자의 라이딩 활동을 대신 등록할 수 있습니다.
+  - 요청 본문에는 `description`이 필수이며, 선택적으로 사진 URL, `verification_status`, `points_awarded`, `admin_notes`, `started_at`을 전달할 수 있습니다.
+  - 상태가 `verified`인 경우 기본 경험치 30점을 즉시 지급하고, `points_awarded` 값을 명시하면 해당 경험치로 덮어씁니다.
+  - `verification_status`가 `pending` 또는 `rejected`인 경우 경험치가 지급되지 않으며, 이후 `/admin/bike-logs/{log_id}/verify`로 검증할 수 있습니다.
+- **관련 문서**: [docs/bike_logs_admin.md](./docs/bike_logs_admin.md)
+
 ### 퀴즈 관련 변경 사항
 
 - 각 퀴즈는 `explanation` 필드로 정답 해설을 포함합니다.

--- a/SWAGGER_GUIDE.md
+++ b/SWAGGER_GUIDE.md
@@ -56,6 +56,8 @@ LikeBike 백엔드 API는 Swagger UI를 통해 문서화되어 있으며, 쉽게
 - 보상 내역 조회
 - 사이클링 목표 관리
 - 사용자 통계 조회
+- 관리자 전용 활동 등록 (`POST /admin/users/{user_id}/bike-logs`)
+- 관리자 검증 (`POST /admin/bike-logs/{log_id}/verify`) 및 CSV 내보내기
 
 ### Course Recommendations (코스 추천)
 

--- a/app/routes/bike_logs.py
+++ b/app/routes/bike_logs.py
@@ -1,7 +1,11 @@
+import base64
+import binascii
 import csv
 import io
 import os
+import re
 import uuid
+from datetime import datetime
 
 import boto3
 from botocore.exceptions import ClientError
@@ -36,12 +40,30 @@ s3_client = (
 )
 
 ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "bmp", "webp"}
+MIME_EXTENSION_MAP = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/bmp": "bmp",
+    "image/webp": "webp",
+}
+DATA_URL_PATTERN = re.compile(r"^data:(?P<mime>[\w\-\./\+]+);base64,(?P<data>.+)$", re.IGNORECASE)
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 
 
 def allowed_file(filename):
     """허용된 파일 확장자인지 확인"""
     return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+class ImageUploadError(Exception):
+    """Base64 이미지를 업로드할 때 발생한 예외"""
+
+    def __init__(self, message, status_code=400):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
 
 
 def upload_file_to_ncp(file, folder_name="bike_logs"):
@@ -92,6 +114,60 @@ def upload_file_to_ncp(file, folder_name="bike_logs"):
         return None, f"파일 업로드 실패: {str(e)}"
     except Exception as e:
         return None, f"알 수 없는 오류: {str(e)}"
+
+
+def upload_data_url_image_to_ncp(data_url: str, folder_name: str = "bike_logs") -> str:
+    """data URL(base64) 이미지를 NCP Object Storage에 업로드하고 URL 반환"""
+
+    if not s3_client:
+        raise ImageUploadError("NCP Object Storage 설정이 완료되지 않았습니다", 500)
+
+    if not data_url or not isinstance(data_url, str):
+        raise ImageUploadError("유효한 data URL 문자열을 제공해야 합니다.")
+
+    match = DATA_URL_PATTERN.match(data_url.strip())
+    if not match:
+        raise ImageUploadError(
+            "유효한 data URL 형식이 아닙니다. 'data:<mime>;base64,<data>' 형식을 사용하세요."
+        )
+
+    mime_type = match.group("mime").lower()
+    base64_payload = match.group("data").strip()
+
+    if mime_type not in MIME_EXTENSION_MAP:
+        raise ImageUploadError(
+            "지원하지 않는 이미지 형식입니다. 허용: "
+            + ", ".join(sorted(MIME_EXTENSION_MAP.keys()))
+        )
+
+    try:
+        image_bytes = base64.b64decode(base64_payload, validate=True)
+    except (binascii.Error, ValueError):
+        raise ImageUploadError("이미지 데이터가 올바른 base64 형식이 아닙니다.")
+
+    if len(image_bytes) > MAX_FILE_SIZE:
+        raise ImageUploadError(
+            f"파일 크기가 너무 큽니다. 최대 {MAX_FILE_SIZE // (1024 * 1024)}MB까지 지원합니다."
+        )
+
+    file_extension = MIME_EXTENSION_MAP[mime_type]
+    object_key = f"{folder_name}/{uuid.uuid4().hex}.{file_extension}"
+
+    try:
+        file_stream = io.BytesIO(image_bytes)
+        file_stream.seek(0)
+        s3_client.upload_fileobj(
+            file_stream,
+            NCP_BUCKET_NAME,
+            object_key,
+            ExtraArgs={"ContentType": mime_type, "ACL": "public-read"},
+        )
+    except ClientError as e:
+        raise ImageUploadError(f"파일 업로드 실패: {str(e)}", 500)
+    except Exception as e:  # pragma: no cover - 예기치 못한 오류 로깅 목적
+        raise ImageUploadError(f"알 수 없는 오류: {str(e)}", 500)
+
+    return f"{NCP_ENDPOINT}/{NCP_BUCKET_NAME}/{object_key}"
 
 
 @bp.route("/users/bike-logs", methods=["POST"])
@@ -452,6 +528,219 @@ def get_pending_bike_logs():
         logs = cur.fetchall()
 
     return make_response(logs)
+
+
+@bp.route("/admin/users/<int:user_id>/bike-logs", methods=["POST"])
+@admin_required
+def create_bike_log_for_user(user_id):
+    """
+    관리자 자전거 활동 기록 생성
+    ---
+    tags:
+      - Bike Logs
+    summary: 특정 사용자를 위한 자전거 활동 기록을 관리자 권한으로 생성
+    description: 관리자가 사용자의 활동 설명 및 인증 상태를 직접 등록합니다.
+    security:
+      - JWT: []
+      - AdminHeader: []
+    parameters:
+      - in: path
+        name: user_id
+        required: true
+        type: integer
+        description: 활동 기록을 생성할 사용자 ID
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - description
+          properties:
+            description:
+              type: string
+              description: 활동 설명
+            bike_photo:
+              type: string
+              description: |
+                자전거 사진 data URL(base64). 예: "data:image/png;base64,iVBORw0KGgo..."
+            safety_gear_photo:
+              type: string
+              description: |
+                안전 장비 사진 data URL(base64). 예: "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
+            verification_status:
+              type: string
+              enum: [pending, verified, rejected]
+              default: verified
+            points_awarded:
+              type: integer
+              description: 검증 완료 시 지급할 경험치 (기본값 30)
+            admin_notes:
+              type: string
+              description: 관리자 메모
+            started_at:
+              type: string
+              description: 활동 시작 시각 (ISO 8601)
+    responses:
+      201:
+        description: 활동 기록 생성 성공
+      400:
+        description: 잘못된 요청
+      401:
+        description: 인증 실패
+      403:
+        description: 관리자 권한 필요
+      404:
+        description: 사용자를 찾을 수 없음
+    """
+    data = request.get_json() or {}
+    description = data.get("description")
+
+    if not description:
+        return make_response({"error": "description required"}, 400)
+
+    verification_status = data.get("verification_status", "verified")
+    allowed_statuses = {"pending", "verified", "rejected"}
+    if verification_status not in allowed_statuses:
+        return make_response(
+            {
+                "error": "verification_status must be one of pending, verified, rejected"
+            },
+            400,
+        )
+
+    started_at_value = None
+    started_at = data.get("started_at")
+    if started_at:
+        try:
+            started_at_value = datetime.fromisoformat(
+                started_at.replace("Z", "+00:00")
+            )
+        except ValueError:
+            return make_response(
+                {"error": "started_at must be ISO 8601 format"}, 400
+            )
+
+    bike_photo_data_url = data.get("bike_photo")
+    safety_gear_photo_data_url = data.get("safety_gear_photo")
+    admin_notes = data.get("admin_notes", "")
+
+    points_awarded_param = data.get("points_awarded")
+    if verification_status == "verified":
+        if points_awarded_param is None:
+            points_awarded = 30
+        else:
+            try:
+                points_awarded = int(points_awarded_param)
+            except (TypeError, ValueError):
+                return make_response(
+                    {"error": "points_awarded must be an integer"}, 400
+                )
+            if points_awarded < 0:
+                return make_response(
+                    {"error": "points_awarded must be non-negative"}, 400
+                )
+    else:
+        if points_awarded_param not in (None, 0):
+            return make_response(
+                {
+                    "error": "points_awarded can only be set when verification_status is 'verified'"
+                },
+                400,
+            )
+        points_awarded = 0
+
+    admin_id = get_current_user_id()
+
+    try:
+        bike_photo_url = (
+            upload_data_url_image_to_ncp(bike_photo_data_url)
+            if bike_photo_data_url
+            else None
+        )
+    except ImageUploadError as exc:
+        return make_response({"error": f"bike_photo: {exc.message}"}, exc.status_code)
+
+    try:
+        safety_gear_photo_url = (
+            upload_data_url_image_to_ncp(safety_gear_photo_data_url)
+            if safety_gear_photo_data_url
+            else None
+        )
+    except ImageUploadError as exc:
+        return make_response({"error": f"safety_gear_photo: {exc.message}"}, exc.status_code)
+
+    db = get_db()
+    with db.cursor() as cur:
+        cur.execute("SELECT id FROM users WHERE id = %s", (user_id,))
+        if not cur.fetchone():
+            return make_response({"error": "user not found"}, 404)
+
+        cur.execute(
+            """
+            INSERT INTO bike_usage_logs (
+                user_id, description, bike_photo_url, safety_gear_photo_url,
+                verification_status, verified_by_admin_id, admin_notes,
+                points_awarded, started_at, verified_at
+            )
+            VALUES (
+                %s, %s, %s, %s, %s,
+                CASE WHEN %s IN ('verified', 'rejected') THEN %s ELSE NULL END,
+                %s, %s,
+                COALESCE(%s, CURRENT_TIMESTAMP),
+                CASE WHEN %s IN ('verified', 'rejected') THEN CURRENT_TIMESTAMP ELSE NULL END
+            )
+            RETURNING id, user_id, description, bike_photo_url, safety_gear_photo_url,
+                      verification_status, points_awarded, admin_notes,
+                      started_at, verified_at, created_at
+            """,
+            (
+                user_id,
+                description,
+                bike_photo_url,
+                safety_gear_photo_url,
+                verification_status,
+                verification_status,
+                admin_id,
+                admin_notes,
+                points_awarded,
+                started_at_value,
+                verification_status,
+            ),
+        )
+
+        log = cur.fetchone()
+
+        if verification_status == "verified" and points_awarded > 0:
+            cur.execute(
+                """
+                UPDATE users
+                SET experience_points = experience_points + %s
+                WHERE id = %s
+                """,
+                (points_awarded, user_id),
+            )
+
+            cur.execute(
+                """
+                INSERT INTO rewards (
+                    user_id, source_type, source_id, points, experience_points,
+                    reward_reason, status
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    user_id,
+                    "bike_usage",
+                    log["id"],
+                    0,
+                    points_awarded,
+                    "자전거 타기 인증 (관리자 등록)",
+                    "completed",
+                ),
+            )
+
+    return make_response(dict(log), 201)
 
 
 @bp.route("/admin/bike-logs/export", methods=["GET"])

--- a/app/utils/timezone.py
+++ b/app/utils/timezone.py
@@ -1,50 +1,89 @@
-from datetime import date, datetime, timezone, timedelta
+"""Timezone helpers used throughout the LikeBike backend."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from typing import Optional, Tuple
+
+__all__ = [
+    "KST",
+    "get_kst_now",
+    "get_kst_today",
+    "kst_datetime_to_utc",
+    "utc_datetime_to_kst",
+    "get_kst_date_range_for_today",
+    "get_kst_week_start_for_sunday_reset",
+]
+
 
 # 한국 시간대 (UTC+9)
 KST = timezone(timedelta(hours=9))
 
 
-def get_kst_now():
+def _ensure_timezone(dt: datetime, tz: timezone) -> datetime:
+    """Ensure *dt* carries *tz* information before conversions."""
+
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=tz)
+    return dt
+
+
+def get_kst_now() -> datetime:
     """현재 한국 시간을 반환합니다."""
+
     return datetime.now(KST)
 
 
 def get_kst_today():
     """오늘 날짜를 한국 시간대 기준으로 반환합니다."""
+
     return get_kst_now().date()
 
 
-def kst_datetime_to_utc(kst_dt):
+def kst_datetime_to_utc(kst_dt: datetime) -> datetime:
     """한국 시간의 datetime을 UTC로 변환합니다."""
-    if kst_dt.tzinfo is None:
-        # naive datetime인 경우 KST로 가정
-        kst_dt = kst_dt.replace(tzinfo=KST)
-    return kst_dt.astimezone(timezone.utc)
+
+    aware_kst = _ensure_timezone(kst_dt, KST)
+    return aware_kst.astimezone(timezone.utc)
 
 
-def utc_datetime_to_kst(utc_dt):
+def utc_datetime_to_kst(utc_dt: datetime) -> datetime:
     """UTC datetime을 한국 시간으로 변환합니다."""
-    if utc_dt.tzinfo is None:
-        # naive datetime인 경우 UTC로 가정
-        utc_dt = utc_dt.replace(tzinfo=timezone.utc)
-    return utc_dt.astimezone(KST)
+
+    aware_utc = _ensure_timezone(utc_dt, timezone.utc)
+    return aware_utc.astimezone(KST)
 
 
-def get_kst_date_range_for_today():
-    """
-    오늘 하루의 시작과 끝을 UTC 시간으로 반환합니다.
-    데이터베이스 쿼리에서 사용할 수 있습니다.
-    """
+def get_kst_date_range_for_today() -> Tuple[datetime, datetime]:
+    """오늘 하루의 시작과 끝을 UTC 시간으로 반환합니다."""
+
     today_kst = get_kst_today()
-    
-    # 오늘 00:00:00 KST를 UTC로 변환
-    start_of_day_kst = datetime.combine(today_kst, datetime.min.time()).replace(tzinfo=KST)
+
+    start_of_day_kst = datetime.combine(today_kst, time.min, tzinfo=KST)
     start_of_day_utc = start_of_day_kst.astimezone(timezone.utc)
-    
-    # 내일 00:00:00 KST를 UTC로 변환 (하루 끝)
+
     end_of_day_kst = start_of_day_kst + timedelta(days=1)
     end_of_day_utc = end_of_day_kst.astimezone(timezone.utc)
-    
+
     return start_of_day_utc, end_of_day_utc
 
 
+def get_kst_week_start_for_sunday_reset(
+    reference: Optional[datetime] = None,
+) -> datetime:
+    """Return the weekly reset boundary (Sunday 00:00 KST) in UTC.
+
+    Args:
+        reference: 기준 시각. 지정하지 않으면 현재 UTC 시간이 사용됩니다.
+    """
+
+    if reference is None:
+        reference = datetime.now(timezone.utc)
+
+    aware_reference = _ensure_timezone(reference, timezone.utc).astimezone(KST)
+
+    days_since_sunday = (aware_reference.weekday() + 1) % 7
+    sunday_date = aware_reference.date() - timedelta(days=days_since_sunday)
+    sunday_start_kst = datetime.combine(sunday_date, time.min, tzinfo=KST)
+
+    return sunday_start_kst.astimezone(timezone.utc)

--- a/docs/bike_logs_admin.md
+++ b/docs/bike_logs_admin.md
@@ -1,0 +1,42 @@
+# 관리자 자전거 활동 등록 가이드
+
+LikeBike 관리자 패널에서는 이용자 대신 자전거 활동을 수기로 등록할 수 있습니다. 이 문서는 새로 추가된 엔드포인트와
+검증 흐름을 정리합니다.
+
+## 엔드포인트 요약
+
+| Method | Path | 설명 |
+| ------ | ---- | ---- |
+| `POST` | `/admin/users/{user_id}/bike-logs` | 관리자가 특정 사용자의 활동을 직접 등록 |
+
+### 요청 본문
+
+```json
+{
+  "description": "필수. 활동 설명",
+  "bike_photo": "선택. data URL(base64) 자전거 사진",
+  "safety_gear_photo": "선택. data URL(base64) 안전 장비 사진",
+  "verification_status": "선택. pending/verified/rejected 중 하나 (기본 verified)",
+  "points_awarded": "선택. verified 상태일 때 지급할 경험치 (기본 30)",
+  "admin_notes": "선택. 관리자 메모",
+  "started_at": "선택. 활동 시작 시각 (ISO 8601)"
+}
+```
+
+### 응답
+
+- `201 Created` + 생성된 로그 정보를 반환합니다. 응답에는 업로드된 이미지의 퍼블릭 URL이 포함됩니다.
+- `400 Bad Request` + 필수 항목 누락, 상태/포인트 값이 잘못된 경우
+- `404 Not Found` + 대상 사용자가 존재하지 않는 경우
+
+## 경험치 및 보상 처리
+
+- 상태가 `verified`이고 경험치가 0보다 크면 즉시 사용자 경험치를 누적하고 `rewards` 테이블에 `bike_usage` 유형으로 기록합니다.
+- `pending` 또는 `rejected` 상태로 생성하면 경험치가 지급되지 않으며, 이후 `/admin/bike-logs/{log_id}/verify`로 상태를 변경할 수
+  있습니다.
+
+## 참고
+
+- 사용자당 하루 한 번의 자가 인증 제한은 여전히 `/users/bike-logs` 엔드포인트에 적용됩니다.
+- 이미지는 `data:<mime>;base64,<data>` 형식의 data URL로 전달해야 하며, JPG/PNG/GIF/BMP/WebP 형식을 지원합니다.
+- 주간 초기화 시점은 `app.utils.timezone.get_kst_week_start_for_sunday_reset` 함수를 활용해 일요일 00:00 KST 기준으로 계산합니다.

--- a/tests/test_bike_logs.py
+++ b/tests/test_bike_logs.py
@@ -1,5 +1,6 @@
+import base64
 import io
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -59,6 +60,11 @@ def admin_user(app):
 def create_fake_image():
     """테스트용 가짜 이미지 파일 생성"""
     return (io.BytesIO(b"fake image data"), "test_image.jpg")
+
+
+def create_fake_data_url():
+    encoded = base64.b64encode(b"fake image data").decode("ascii")
+    return f"data:image/png;base64,{encoded}"
 
 
 @patch("app.routes.bike_logs.upload_file_to_ncp")
@@ -295,6 +301,136 @@ def test_get_pending_bike_logs_non_admin(client, test_user):
 
     res = client.get("/admin/bike-logs", headers=headers)
     assert res.status_code == 403
+
+
+@patch("app.routes.bike_logs.upload_data_url_image_to_ncp")
+def test_admin_create_bike_log_for_user(
+    mock_upload_data_url, client, app, admin_user, test_user
+):
+    """관리자가 자전거 활동 기록을 직접 생성할 수 있다"""
+    token = get_test_jwt_token(admin_user, "admin", "admin@example.com", is_admin=True)
+    headers = get_admin_headers(token)
+
+    mock_upload_data_url.side_effect = [
+        "https://example.com/bike.jpg",
+        "https://example.com/gear.jpg",
+    ]
+
+    payload = {
+        "description": "관리자 등록 라이딩",
+        "bike_photo": create_fake_data_url(),
+        "safety_gear_photo": create_fake_data_url(),
+        "verification_status": "verified",
+        "points_awarded": 45,
+        "admin_notes": "오프라인 이벤트 참여",
+    }
+
+    res = client.post(
+        f"/admin/users/{test_user}/bike-logs", json=payload, headers=headers
+    )
+
+    assert res.status_code == 201
+    data = res.get_json()["data"][0]
+    assert data["user_id"] == test_user
+    assert data["description"] == payload["description"]
+    assert data["bike_photo_url"] == "https://example.com/bike.jpg"
+    assert data["safety_gear_photo_url"] == "https://example.com/gear.jpg"
+    assert data["verification_status"] == "verified"
+    assert data["points_awarded"] == 45
+    assert data["admin_notes"] == payload["admin_notes"]
+    assert data["verified_at"] is not None
+    assert mock_upload_data_url.call_count == 2
+
+    with app.app_context():
+        db = get_db()
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT experience_points FROM users WHERE id = %s", (test_user,)
+            )
+            assert cur.fetchone()["experience_points"] == 45
+
+            cur.execute(
+                "SELECT COUNT(*) AS cnt FROM rewards WHERE user_id = %s AND source_type = %s",
+                (test_user, "bike_usage"),
+            )
+            assert cur.fetchone()["cnt"] == 1
+
+
+def test_admin_create_bike_log_pending_status(client, app, admin_user, test_user):
+    """대기 상태로 등록 시 경험치가 지급되지 않는다"""
+    token = get_test_jwt_token(admin_user, "admin", "admin@example.com", is_admin=True)
+    headers = get_admin_headers(token)
+
+    payload = {"description": "대기 기록", "verification_status": "pending"}
+
+    res = client.post(
+        f"/admin/users/{test_user}/bike-logs", json=payload, headers=headers
+    )
+
+    assert res.status_code == 201
+    data = res.get_json()["data"][0]
+    assert data["verification_status"] == "pending"
+    assert data["points_awarded"] == 0
+    assert data["verified_at"] is None
+
+
+def test_admin_create_bike_log_invalid_photo(client, admin_user, test_user):
+    """잘못된 base64 data URL은 400을 반환한다"""
+
+    token = get_test_jwt_token(admin_user, "admin", "admin@example.com", is_admin=True)
+    headers = get_admin_headers(token)
+
+    payload = {
+        "description": "유효하지 않은 사진",
+        "bike_photo": "not-a-valid-data-url",
+    }
+
+    res = client.post(
+        f"/admin/users/{test_user}/bike-logs", json=payload, headers=headers
+    )
+
+    assert res.status_code == 400
+    assert "bike_photo" in res.get_json()["data"][0]["error"]
+
+
+def test_admin_create_bike_log_invalid_status(client, admin_user, test_user):
+    """허용되지 않은 상태 값은 오류를 발생시킨다"""
+    token = get_test_jwt_token(admin_user, "admin", "admin@example.com", is_admin=True)
+    headers = get_admin_headers(token)
+
+    res = client.post(
+        f"/admin/users/{test_user}/bike-logs",
+        json={"description": "잘못된 상태", "verification_status": "unknown"},
+        headers=headers,
+    )
+
+    assert res.status_code == 400
+
+
+def test_admin_create_bike_log_missing_description(client, admin_user, test_user):
+    """설명을 입력하지 않으면 400을 반환한다"""
+    token = get_test_jwt_token(admin_user, "admin", "admin@example.com", is_admin=True)
+    headers = get_admin_headers(token)
+
+    res = client.post(
+        f"/admin/users/{test_user}/bike-logs", json={}, headers=headers
+    )
+
+    assert res.status_code == 400
+
+
+def test_admin_create_bike_log_user_not_found(client, admin_user):
+    """존재하지 않는 사용자에 대해 등록 시 404 반환"""
+    token = get_test_jwt_token(admin_user, "admin", "admin@example.com", is_admin=True)
+    headers = get_admin_headers(token)
+
+    res = client.post(
+        "/admin/users/999999/bike-logs",
+        json={"description": "없는 사용자"},
+        headers=headers,
+    )
+
+    assert res.status_code == 404
 
 
 def test_admin_bike_logs_pagination(client, app, admin_user, test_user):


### PR DESCRIPTION
### Description
- allow the admin bike log creation endpoint to accept image data URLs, validate them, and upload to NCP storage before persisting the log
- document the new data URL payload requirements and update tests to cover successful uploads and invalid data handling

### Testing Done
- `PYTHONPATH=. pytest tests/test_bike_logs.py -q` *(fails: connection to localhost:5432 refused)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69102651319c83219fef7e115a4e6fd5)