### PR TITLE
fix(recommendations): remove unused weekly limit arg

### DIFF
--- a/app/routes/recommendations.py
+++ b/app/routes/recommendations.py
@@ -8,7 +8,6 @@ from flask import Blueprint, Response, request
 from ..db import get_db
 from ..utils.auth import admin_required, get_current_user_id, jwt_required
 from ..utils.responses import make_response
-from ..utils.timezone import get_kst_week_start_for_sunday_reset
 from .storage import upload_file_to_ncp
 
 bp = Blueprint("recommendations", __name__)
@@ -288,14 +287,13 @@ def create_course_recommendation():
 
     # 주 2회 제한 (서버 시간 기준 일요일 00:00에 초기화)
     db = get_db()
-    week_start_utc = get_kst_week_start_for_sunday_reset()
     with db.cursor() as cur:
         cur.execute(
             "SELECT COUNT(*) as count FROM course_recommendations"
             " WHERE user_id = %s"
             " AND created_at >= date_trunc('week', CURRENT_TIMESTAMP + INTERVAL '1 day') - INTERVAL '1 day'"
             " AND status != 'rejected'",
-            (user_id, week_start_utc),
+            (user_id,),
         )
         result = cur.fetchone()
         if result and result["count"] >= 2:


### PR DESCRIPTION
### Description
* remove the unused `week_start_utc` parameter from the weekly course recommendation limit query to avoid psycopg2 parameter mismatches

### Testing Done
* pytest -q *(fails: ModuleNotFoundError: No module named 'app')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bb4b67fc8321a0a0192b8d58d838)