### PR TITLE
feat(routes): add biweekly activity summary endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,7 @@ from flask_cors import CORS
 
 from . import db
 from .routes import main as main_blueprint
+from .routes.activity_summary import bp as activity_summary_bp
 from .routes.bike_logs import bp as bike_logs_bp
 from .routes.community import bp as community_bp
 from .routes.news import bp as news_bp
@@ -188,6 +189,7 @@ def create_app(test_config=None):
     app.register_blueprint(storage_bp)
     app.register_blueprint(recommendations_bp)
     app.register_blueprint(rewards_bp)
+    app.register_blueprint(activity_summary_bp)
 
     # Swagger 설정
     swagger_config = {

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -38,8 +38,17 @@ def test_route():
 # 모든 라우트 블루프린트를 등록하는 함수
 def register_routes(app):
     """애플리케이션에 모든 라우트를 등록"""
-    from . import (bike_logs, community, news, quizzes, recommendations,
-                   rewards, storage, users)
+    from . import (
+        activity_summary,
+        bike_logs,
+        community,
+        news,
+        quizzes,
+        recommendations,
+        rewards,
+        storage,
+        users,
+    )
 
     app.register_blueprint(main)
     app.register_blueprint(users.bp)
@@ -50,3 +59,4 @@ def register_routes(app):
     app.register_blueprint(storage.bp)
     app.register_blueprint(recommendations.bp)
     app.register_blueprint(rewards.bp)
+    app.register_blueprint(activity_summary.bp)

--- a/app/routes/activity_summary.py
+++ b/app/routes/activity_summary.py
@@ -1,0 +1,121 @@
+"""Activity summary endpoints."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+from flask import Blueprint
+
+from ..db import get_db
+from ..utils.auth import get_current_user, get_current_user_id, jwt_required
+from ..utils.responses import make_response
+
+bp = Blueprint("activity_summary", __name__)
+
+
+def _get_period_range() -> tuple[datetime, datetime]:
+    """Return the UTC datetime range covering the last 14 days."""
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=14)
+    return start, end
+
+
+@bp.route("/users/<int:user_id>/activity-summary", methods=["GET"])
+@jwt_required
+def get_biweekly_activity_summary(user_id: int):
+    """Return a human-readable activity summary for the last two weeks."""
+
+    current_user = get_current_user()
+    current_user_id = get_current_user_id()
+    if current_user_id != user_id and not (current_user and current_user.get("is_admin")):
+        return make_response({"error": "Forbidden"}, 403)
+
+    db = get_db()
+    with db.cursor() as cur:
+        cur.execute("SELECT username FROM users WHERE id = %s", (user_id,))
+        user_row = cur.fetchone()
+        if not user_row:
+            return make_response({"error": "user not found"}, 404)
+
+        username: str = user_row["username"] if isinstance(user_row, dict) else user_row[0]
+
+        start, end = _get_period_range()
+
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS attempts,
+                COALESCE(SUM(CASE WHEN is_correct THEN 1 ELSE 0 END), 0) AS correct
+            FROM user_quiz_attempts
+            WHERE user_id = %s AND attempted_at >= %s AND attempted_at < %s
+            """,
+            (user_id, start, end),
+        )
+        quiz_row = cur.fetchone() or {"attempts": 0, "correct": 0}
+        quiz_attempts = int(quiz_row.get("attempts", 0))
+        quiz_correct = int(quiz_row.get("correct", 0))
+        quiz_accuracy = (quiz_correct / quiz_attempts) * 100 if quiz_attempts else 0.0
+
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS total,
+                COALESCE(SUM(CASE WHEN verification_status = 'verified' THEN 1 ELSE 0 END), 0) AS approved
+            FROM bike_usage_logs
+            WHERE user_id = %s AND created_at >= %s AND created_at < %s
+            """,
+            (user_id, start, end),
+        )
+        bike_row = cur.fetchone() or {"total": 0, "approved": 0}
+        bike_attempts = int(bike_row.get("total", 0))
+        bike_approved = int(bike_row.get("approved", 0))
+
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS total,
+                COALESCE(SUM(CASE WHEN status = 'verified' THEN 1 ELSE 0 END), 0) AS approved,
+                COALESCE(SUM(CASE WHEN status = 'verified' THEN points_awarded ELSE 0 END), 0) AS points
+            FROM course_recommendations
+            WHERE user_id = %s AND created_at >= %s AND created_at < %s
+            """,
+            (user_id, start, end),
+        )
+        course_row = cur.fetchone() or {"total": 0, "approved": 0, "points": 0}
+        course_total = int(course_row.get("total", 0))
+        course_approved = int(course_row.get("approved", 0))
+        course_points = int(course_row.get("points", 0))
+
+    summary_text = (
+        f"지난 2주 동안 {username}님은 안전 퀴즈를 {quiz_attempts}문제 풀었고, "
+        f"정답률은 {quiz_accuracy:.0f}%였어요.\n"
+        f"자전거 활동 인증은 {bike_attempts}회 시도했고, 이 중 {bike_approved}회가 승인되었어요.\n"
+        f"코스 추천은 {course_total}개를 등록해서 {course_approved}개가 승인되었고, 총 {course_points}포인트를 획득했습니다!"
+    )
+
+    payload: Dict[str, Any] = {
+        "user_id": user_id,
+        "username": username,
+        "period": {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        },
+        "quizzes": {
+            "attempts": quiz_attempts,
+            "correct": quiz_correct,
+            "accuracy": round(quiz_accuracy, 2),
+        },
+        "bike_logs": {
+            "attempts": bike_attempts,
+            "approved": bike_approved,
+        },
+        "course_recommendations": {
+            "submitted": course_total,
+            "approved": course_approved,
+            "points": course_points,
+        },
+        "summary_text": summary_text,
+    }
+
+    return make_response(payload)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_activity_summary.py
+++ b/tests/test_activity_summary.py
@@ -1,0 +1,162 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import create_app
+from app.db import get_db
+from app.utils.auth import generate_jwt_token
+
+
+@pytest.fixture
+def client():
+    app = create_app({"TESTING": True})
+    with app.test_client() as client:
+        yield client
+
+
+def _insert_sample_data(app):
+    with app.app_context():
+        db = get_db()
+        with db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO user_levels (level, level_name, required_exp) VALUES (%s, %s, %s)"
+                " ON CONFLICT (level) DO NOTHING",
+                (1, "Beginner", 0),
+            )
+            cur.execute(
+                """
+                INSERT INTO users (kakao_id, username, email, level)
+                VALUES (%s, %s, %s, %s)
+                RETURNING id, username
+                """,
+                ("kakao-1", "테스트", "test@example.com", 1),
+            )
+            user = cur.fetchone()
+            user_id = user["id"]
+
+            now = datetime.now(timezone.utc)
+            within_period = now - timedelta(days=3)
+            outside_period = now - timedelta(days=20)
+
+            quiz_rows = [
+                (user_id, 1, True, within_period),
+                (user_id, 2, True, within_period),
+                (user_id, 3, True, within_period),
+                (user_id, 4, False, within_period),
+                (user_id, 5, True, outside_period),
+            ]
+            args_str = ",".join(["(%s, %s, %s, %s)"] * len(quiz_rows))
+            cur.execute(
+                f"""
+                INSERT INTO user_quiz_attempts (user_id, quiz_id, is_correct, attempted_at)
+                VALUES {args_str}
+                """,
+                [value for row in quiz_rows for value in row],
+            )
+
+            bike_rows = [
+                (
+                    user_id,
+                    "첫 번째 라이딩",
+                    "verified",
+                    within_period,
+                ),
+                (
+                    user_id,
+                    "두 번째 라이딩",
+                    "verified",
+                    within_period,
+                ),
+                (
+                    user_id,
+                    "세 번째 라이딩",
+                    "pending",
+                    within_period,
+                ),
+                (
+                    user_id,
+                    "네 번째 라이딩",
+                    "verified",
+                    outside_period,
+                ),
+            ]
+            args_str = ",".join(["(%s, %s, %s, %s)"] * len(bike_rows))
+            cur.execute(
+                f"""
+                INSERT INTO bike_usage_logs (
+                    user_id,
+                    description,
+                    verification_status,
+                    created_at
+                )
+                VALUES {args_str}
+                """,
+                [value for row in bike_rows for value in row],
+            )
+
+            course_rows = [
+                (
+                    user_id,
+                    "멋진 코스",
+                    "verified",
+                    200,
+                    within_period,
+                ),
+                (
+                    user_id,
+                    "재미있는 코스",
+                    "pending",
+                    0,
+                    within_period,
+                ),
+                (
+                    user_id,
+                    "오래된 코스",
+                    "verified",
+                    100,
+                    outside_period,
+                ),
+            ]
+            args_str = ",".join(["(%s, %s, %s, %s, %s)"] * len(course_rows))
+            cur.execute(
+                f"""
+                INSERT INTO course_recommendations (
+                    user_id,
+                    title,
+                    status,
+                    points_awarded,
+                    created_at
+                )
+                VALUES {args_str}
+                """,
+                [value for row in course_rows for value in row],
+            )
+
+    return user_id
+
+
+def test_activity_summary_endpoint(client):
+    app = client.application
+    user_id = _insert_sample_data(app)
+    token = generate_jwt_token(user_id, username="테스트", is_admin=False)
+
+    response = client.get(
+        f"/users/{user_id}/activity-summary",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    data = payload["data"][0]
+
+    assert data["user_id"] == user_id
+    assert data["quizzes"]["attempts"] == 4
+    assert data["quizzes"]["correct"] == 3
+    assert data["quizzes"]["accuracy"] == 75.0
+    assert data["bike_logs"]["attempts"] == 3
+    assert data["bike_logs"]["approved"] == 2
+    assert data["course_recommendations"]["submitted"] == 2
+    assert data["course_recommendations"]["approved"] == 1
+    assert data["course_recommendations"]["points"] == 200
+    assert "지난 2주 동안" in data["summary_text"]
+    assert "정답률은 75%" in data["summary_text"]


### PR DESCRIPTION
### Description
- add an activity summary endpoint that aggregates a user's last-two-week stats and returns a friendly recap message
- register the new blueprint with the Flask app factory and the route registry
- add focused tests for the summary output along with shared test path setup

### Testing Done
- pytest tests/test_activity_summary.py -q *(fails: connection to localhost:5432 refused because no Postgres instance is available in the test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c79a497c8321acd68a1fada8ff5b)